### PR TITLE
feat: pylint with modern pylintrc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,8 @@
           "oderwat.indent-rainbow",
           "redhat.vscode-yaml",
           "spmeesseman.vscode-taskexplorer",
-          "visualstudioexptteam.vscodeintellicode"
+          "visualstudioexptteam.vscodeintellicode",
+          "ms-python.pylint"
       ],
       "settings": {
           "terminal.integrated.defaultProfile.linux": "zsh",

--- a/.pylintrc
+++ b/.pylintrc
@@ -46,8 +46,7 @@ fail-under=10
 #from-stdin=
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore=CVS,
-       migrations
+ignore=CVS
 
 # Add files or directories matching the regular expressions patterns to the
 # ignore-list. The regex matches against paths and can be in Posix or Windows
@@ -58,7 +57,7 @@ ignore-paths=
 # Files or directories matching the regular expression patterns are skipped.
 # The regex matches against base names, not paths. The default value ignores
 # Emacs file locks
-ignore-patterns=
+ignore-patterns=^\.#
 
 # List of module names for which member attributes should not be checked and
 # will not be imported (useful for modules/projects where namespaces are
@@ -83,8 +82,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=pylint_django,
-             pylint_common
+load-plugins=
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -126,7 +124,7 @@ argument-naming-style=snake_case
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style. If left empty, argument names will be checked with the set
 # naming style.
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
+#argument-rgx=
 
 # Naming style matching correct attribute names.
 attr-naming-style=snake_case
@@ -134,7 +132,7 @@ attr-naming-style=snake_case
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style. If left empty, attribute names will be checked with the set naming
 # style.
-attr-rgx=[a-z_][a-z0-9_]{2,30}$
+#attr-rgx=
 
 # Bad variable names which should always be refused, separated by a comma.
 bad-names=foo,
@@ -154,7 +152,7 @@ class-attribute-naming-style=any
 # Regular expression matching correct class attribute names. Overrides class-
 # attribute-naming-style. If left empty, class attribute names will be checked
 # with the set naming style.
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+#class-attribute-rgx=
 
 # Naming style matching correct class constant names.
 class-const-naming-style=UPPER_CASE
@@ -169,7 +167,7 @@ class-naming-style=PascalCase
 
 # Regular expression matching correct class names. Overrides class-naming-
 # style. If left empty, class names will be checked with the set naming style.
-class-rgx=[A-Z_][a-zA-Z0-9]+$
+#class-rgx=
 
 # Naming style matching correct constant names.
 const-naming-style=UPPER_CASE
@@ -177,7 +175,7 @@ const-naming-style=UPPER_CASE
 # Regular expression matching correct constant names. Overrides const-naming-
 # style. If left empty, constant names will be checked with the set naming
 # style.
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+#const-rgx=
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
@@ -189,7 +187,7 @@ function-naming-style=snake_case
 # Regular expression matching correct function names. Overrides function-
 # naming-style. If left empty, function names will be checked with the set
 # naming style.
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+#function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
 good-names=i,
@@ -212,21 +210,21 @@ inlinevar-naming-style=any
 # Regular expression matching correct inline iteration names. Overrides
 # inlinevar-naming-style. If left empty, inline iteration names will be checked
 # with the set naming style.
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+#inlinevar-rgx=
 
 # Naming style matching correct method names.
 method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style. If left empty, method names will be checked with the set naming style.
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+#method-rgx=
 
 # Naming style matching correct module names.
 module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
 # style. If left empty, module names will be checked with the set naming style.
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+#module-rgx=
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.
@@ -255,7 +253,7 @@ variable-naming-style=snake_case
 # Regular expression matching correct variable names. Overrides variable-
 # naming-style. If left empty, variable names will be checked with the set
 # naming style.
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
+#variable-rgx=
 
 
 [CLASSES]
@@ -266,15 +264,13 @@ check-protected-access-in-special-methods=no
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,
                       __new__,
-                      setUp
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
 
 # List of member names, which should be excluded from the protected access
 # warning.
-exclude-protected=_asdict,
-                  _fields,
-                  _replace,
-                  _source,
-                  _make
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls
@@ -324,16 +320,10 @@ max-statements=50
 min-public-methods=2
 
 
-[DJANGO FOREIGN KEYS REFERENCED BY STRINGS]
-
-# A module containing Django settings to be used while linting.
-#django-settings-module=
-
-
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=builtins.Exception
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
 
 
 [FORMAT]
@@ -379,10 +369,7 @@ allow-reexport-from-package=no
 allow-wildcard-with-all=no
 
 # Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=regsub,
-                   TERMIOS,
-                   Bastion,
-                   rexec
+deprecated-modules=
 
 # Output a graph (.gv or any supported image format) of external dependencies
 # to the given file (report RP0402 must not be disabled).
@@ -448,252 +435,7 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
-        use-implicit-booleaness-not-comparison-to-zero,
-        unknown-option-value,
-        fixme,
-        useless-with-lock,
-        logging-not-lazy,
-        logging-format-interpolation,
-        logging-fstring-interpolation,
-        bad-format-string-key,
-        unused-format-string-key,
-        bad-format-string,
-        missing-format-argument-key,
-        unused-format-string-argument,
-        format-combined-specification,
-        missing-format-attribute,
-        invalid-format-index,
-        duplicate-string-formatting-argument,
-        f-string-without-interpolation,
-        format-string-without-interpolation,
-        anomalous-backslash-in-string,
-        anomalous-unicode-escape-in-string,
-        implicit-str-concat,
-        inconsistent-quotes,
-        redundant-u-string-prefix,
-        global-variable-undefined,
-        global-variable-not-assigned,
-        global-statement,
-        global-at-module-level,
-        unused-import,
-        unused-variable,
-        unused-argument,
-        unused-wildcard-import,
-        redefined-outer-name,
-        redefined-builtin,
-        undefined-loop-variable,
-        unbalanced-tuple-unpacking,
-        cell-var-from-loop,
-        possibly-unused-variable,
-        self-cls-assignment,
-        unbalanced-dict-unpacking,
-        modified-iterating-list,
-        attribute-defined-outside-init,
-        bad-staticmethod-argument,
-        protected-access,
-        implicit-flag-alias,
-        arguments-differ,
-        signature-differs,
-        abstract-method,
-        super-init-not-called,
-        non-parent-init-called,
-        invalid-overridden-method,
-        arguments-renamed,
-        unused-private-member,
-        overridden-final-method,
-        subclassed-final-class,
-        redefined-slots-in-subclass,
-        super-without-brackets,
-        useless-parent-delegation,
-        bad-open-mode,
-        boolean-datetime,
-        redundant-unittest-assert,
-        bad-thread-instantiation,
-        shallow-copy-environ,
-        invalid-envvar-default,
-        subprocess-popen-preexec-fn,
-        subprocess-run-check,
-        unspecified-encoding,
-        forgotten-debug-statement,
-        method-cache-max-size-none,
-        deprecated-method,
-        deprecated-argument,
-        deprecated-class,
-        deprecated-decorator,
-        deprecated-attribute,
-        non-ascii-file-name,
-        useless-else-on-loop,
-        unreachable,
-        dangerous-default-value,
-        pointless-statement,
-        pointless-string-statement,
-        expression-not-assigned,
-        unnecessary-lambda,
-        duplicate-key,
-        exec-used,
-        eval-used,
-        confusing-with-statement,
-        using-constant-test,
-        missing-parentheses-for-call-in-test,
-        self-assigning-variable,
-        redeclared-assigned-name,
-        assert-on-string-literal,
-        duplicate-value,
-        named-expr-without-context,
-        pointless-exception-statement,
-        return-in-finally,
-        lost-exception,
-        assert-on-tuple,
-        unnecessary-pass,
-        comparison-with-callable,
-        nan-comparison,
-        contextmanager-generator-missing-cleanup,
-        bad-chained-comparison,
-        unnecessary-semicolon,
-        bad-indentation,
-        nested-min-max,
-        bare-except,
-        duplicate-except,
-        try-except-raise,
-        raise-missing-from,
-        binary-op-exception,
-        raising-format-tuple,
-        wrong-exception-operation,
-        broad-exception-caught,
-        broad-exception-raised,
-        unnecessary-ellipsis,
-        using-f-string-in-unsupported-version,
-        using-final-decorator-in-unsupported-version,
-        wildcard-import,
-        reimported,
-        import-self,
-        preferred-module,
-        misplaced-future,
-        shadowed-import,
-        deprecated-module,
-        missing-timeout,
-        keyword-arg-before-vararg,
-        arguments-out-of-order,
-        non-str-assignment-to-dunder-name,
-        isinstance-second-argument-not-valid-type,
-        kwarg-superseded-by-positional-arg,
-        model-missing-unicode,
-        model-has-unicode,
-        model-no-explicit-unicode,
-        django-not-available-placeholder,
-        modelform-uses-exclude,
-        wrong-spelling-in-comment,
-        wrong-spelling-in-docstring,
-        invalid-characters-in-docstring,
-        bad-file-encoding,
-        bad-classmethod-argument,
-        bad-mcs-method-argument,
-        bad-mcs-classmethod-argument,
-        single-string-used-for-slots,
-        non-ascii-name,
-        non-ascii-module-import,
-        invalid-name,
-        disallowed-name,
-        typevar-name-incorrect-variance,
-        typevar-double-variance,
-        typevar-name-mismatch,
-        empty-docstring,
-        missing-module-docstring,
-        missing-class-docstring,
-        missing-function-docstring,
-        singleton-comparison,
-        unidiomatic-typecheck,
-        unnecessary-lambda-assignment,
-        unnecessary-direct-lambda-call,
-        line-too-long,
-        too-many-lines,
-        trailing-whitespace,
-        missing-final-newline,
-        trailing-newlines,
-        multiple-statements,
-        superfluous-parens,
-        mixed-line-endings,
-        unexpected-line-ending-format,
-        unnecessary-dunder-call,
-        unnecessary-negation,
-        consider-using-enumerate,
-        consider-iterating-dictionary,
-        consider-using-dict-items,
-        use-maxsplit-arg,
-        use-sequence-for-iteration,
-        consider-using-f-string,
-        use-implicit-booleaness-not-len,
-        use-implicit-booleaness-not-comparison,
-        multiple-imports,
-        wrong-import-order,
-        ungrouped-imports,
-        wrong-import-position,
-        useless-import-alias,
-        import-outside-toplevel,
-        useless-option-value,
-        no-classmethod-decorator,
-        no-staticmethod-decorator,
-        useless-object-inheritance,
-        property-with-parameters,
-        literal-comparison,
-        comparison-with-itself,
-        comparison-of-constants,
-        too-many-ancestors,
-        too-many-instance-attributes,
-        too-few-public-methods,
-        too-many-public-methods,
-        too-many-return-statements,
-        too-many-branches,
-        too-many-arguments,
-        too-many-locals,
-        too-many-statements,
-        too-many-boolean-expressions,
-        too-many-positional,
-        consider-merging-isinstance,
-        too-many-nested-blocks,
-        simplifiable-if-statement,
-        redefined-argument-from-local,
-        no-else-return,
-        consider-using-ternary,
-        trailing-comma-tuple,
-        stop-iteration-return,
-        simplify-boolean-expression,
-        inconsistent-return-statements,
-        useless-return,
-        consider-swap-variables,
-        consider-using-join,
-        consider-using-in,
-        consider-using-get,
-        chained-comparison,
-        consider-using-dict-comprehension,
-        consider-using-set-comprehension,
-        simplifiable-if-expression,
-        no-else-raise,
-        unnecessary-comprehension,
-        consider-using-sys-exit,
-        no-else-break,
-        no-else-continue,
-        super-with-arguments,
-        simplifiable-condition,
-        condition-evals-to-constant,
-        consider-using-generator,
-        use-a-generator,
-        consider-using-min-builtin,
-        consider-using-max-builtin,
-        consider-using-with,
-        unnecessary-dict-index-lookup,
-        use-list-literal,
-        use-dict-literal,
-        unnecessary-list-index-lookup,
-        use-yield-from,
-        duplicate-code,
-        cyclic-import,
-        consider-using-from-import,
-        http-response-with-json-dumps,
-        http-response-with-content-type-json,
-        redundant-content-type-for-json-response,
-        c-extension-no-member,
-        no-member
+        use-implicit-booleaness-not-comparison-to-zero
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -744,7 +486,7 @@ suggest-join-with-non-empty-separator=yes
 # 'convention', and 'info' which contain the number of messages in each
 # category, as well as 'statement' which is the total number of statements
 # analyzed. This score is used by the global evaluation report (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details.
@@ -772,7 +514,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Imports are removed from the similarity computation
-ignore-imports=no
+ignore-imports=yes
 
 # Signatures are removed from the similarity computation
 ignore-signatures=yes
@@ -849,7 +591,7 @@ ignored-checks-for-mixins=no-member,
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.
@@ -889,14 +631,14 @@ callbacks=cb_,
 
 # A regular expression matching the name of dummy variables (i.e. expected to
 # not be used).
-dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
 # Argument names that match this expression will be ignored.
-ignored-argument-names=_.*
+ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
 init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,future.builtins
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,902 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS,
+       migrations
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=pylint_django,
+             pylint_common
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[DJANGO FOREIGN KEYS REFERENCED BY STRINGS]
+
+# A module containing Django settings to be used while linting.
+#django-settings-module=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        unknown-option-value,
+        fixme,
+        useless-with-lock,
+        logging-not-lazy,
+        logging-format-interpolation,
+        logging-fstring-interpolation,
+        bad-format-string-key,
+        unused-format-string-key,
+        bad-format-string,
+        missing-format-argument-key,
+        unused-format-string-argument,
+        format-combined-specification,
+        missing-format-attribute,
+        invalid-format-index,
+        duplicate-string-formatting-argument,
+        f-string-without-interpolation,
+        format-string-without-interpolation,
+        anomalous-backslash-in-string,
+        anomalous-unicode-escape-in-string,
+        implicit-str-concat,
+        inconsistent-quotes,
+        redundant-u-string-prefix,
+        global-variable-undefined,
+        global-variable-not-assigned,
+        global-statement,
+        global-at-module-level,
+        unused-import,
+        unused-variable,
+        unused-argument,
+        unused-wildcard-import,
+        redefined-outer-name,
+        redefined-builtin,
+        undefined-loop-variable,
+        unbalanced-tuple-unpacking,
+        cell-var-from-loop,
+        possibly-unused-variable,
+        self-cls-assignment,
+        unbalanced-dict-unpacking,
+        modified-iterating-list,
+        attribute-defined-outside-init,
+        bad-staticmethod-argument,
+        protected-access,
+        implicit-flag-alias,
+        arguments-differ,
+        signature-differs,
+        abstract-method,
+        super-init-not-called,
+        non-parent-init-called,
+        invalid-overridden-method,
+        arguments-renamed,
+        unused-private-member,
+        overridden-final-method,
+        subclassed-final-class,
+        redefined-slots-in-subclass,
+        super-without-brackets,
+        useless-parent-delegation,
+        bad-open-mode,
+        boolean-datetime,
+        redundant-unittest-assert,
+        bad-thread-instantiation,
+        shallow-copy-environ,
+        invalid-envvar-default,
+        subprocess-popen-preexec-fn,
+        subprocess-run-check,
+        unspecified-encoding,
+        forgotten-debug-statement,
+        method-cache-max-size-none,
+        deprecated-method,
+        deprecated-argument,
+        deprecated-class,
+        deprecated-decorator,
+        deprecated-attribute,
+        non-ascii-file-name,
+        useless-else-on-loop,
+        unreachable,
+        dangerous-default-value,
+        pointless-statement,
+        pointless-string-statement,
+        expression-not-assigned,
+        unnecessary-lambda,
+        duplicate-key,
+        exec-used,
+        eval-used,
+        confusing-with-statement,
+        using-constant-test,
+        missing-parentheses-for-call-in-test,
+        self-assigning-variable,
+        redeclared-assigned-name,
+        assert-on-string-literal,
+        duplicate-value,
+        named-expr-without-context,
+        pointless-exception-statement,
+        return-in-finally,
+        lost-exception,
+        assert-on-tuple,
+        unnecessary-pass,
+        comparison-with-callable,
+        nan-comparison,
+        contextmanager-generator-missing-cleanup,
+        bad-chained-comparison,
+        unnecessary-semicolon,
+        bad-indentation,
+        nested-min-max,
+        bare-except,
+        duplicate-except,
+        try-except-raise,
+        raise-missing-from,
+        binary-op-exception,
+        raising-format-tuple,
+        wrong-exception-operation,
+        broad-exception-caught,
+        broad-exception-raised,
+        unnecessary-ellipsis,
+        using-f-string-in-unsupported-version,
+        using-final-decorator-in-unsupported-version,
+        wildcard-import,
+        reimported,
+        import-self,
+        preferred-module,
+        misplaced-future,
+        shadowed-import,
+        deprecated-module,
+        missing-timeout,
+        keyword-arg-before-vararg,
+        arguments-out-of-order,
+        non-str-assignment-to-dunder-name,
+        isinstance-second-argument-not-valid-type,
+        kwarg-superseded-by-positional-arg,
+        model-missing-unicode,
+        model-has-unicode,
+        model-no-explicit-unicode,
+        django-not-available-placeholder,
+        modelform-uses-exclude,
+        wrong-spelling-in-comment,
+        wrong-spelling-in-docstring,
+        invalid-characters-in-docstring,
+        bad-file-encoding,
+        bad-classmethod-argument,
+        bad-mcs-method-argument,
+        bad-mcs-classmethod-argument,
+        single-string-used-for-slots,
+        non-ascii-name,
+        non-ascii-module-import,
+        invalid-name,
+        disallowed-name,
+        typevar-name-incorrect-variance,
+        typevar-double-variance,
+        typevar-name-mismatch,
+        empty-docstring,
+        missing-module-docstring,
+        missing-class-docstring,
+        missing-function-docstring,
+        singleton-comparison,
+        unidiomatic-typecheck,
+        unnecessary-lambda-assignment,
+        unnecessary-direct-lambda-call,
+        line-too-long,
+        too-many-lines,
+        trailing-whitespace,
+        missing-final-newline,
+        trailing-newlines,
+        multiple-statements,
+        superfluous-parens,
+        mixed-line-endings,
+        unexpected-line-ending-format,
+        unnecessary-dunder-call,
+        unnecessary-negation,
+        consider-using-enumerate,
+        consider-iterating-dictionary,
+        consider-using-dict-items,
+        use-maxsplit-arg,
+        use-sequence-for-iteration,
+        consider-using-f-string,
+        use-implicit-booleaness-not-len,
+        use-implicit-booleaness-not-comparison,
+        multiple-imports,
+        wrong-import-order,
+        ungrouped-imports,
+        wrong-import-position,
+        useless-import-alias,
+        import-outside-toplevel,
+        useless-option-value,
+        no-classmethod-decorator,
+        no-staticmethod-decorator,
+        useless-object-inheritance,
+        property-with-parameters,
+        literal-comparison,
+        comparison-with-itself,
+        comparison-of-constants,
+        too-many-ancestors,
+        too-many-instance-attributes,
+        too-few-public-methods,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-branches,
+        too-many-arguments,
+        too-many-locals,
+        too-many-statements,
+        too-many-boolean-expressions,
+        too-many-positional,
+        consider-merging-isinstance,
+        too-many-nested-blocks,
+        simplifiable-if-statement,
+        redefined-argument-from-local,
+        no-else-return,
+        consider-using-ternary,
+        trailing-comma-tuple,
+        stop-iteration-return,
+        simplify-boolean-expression,
+        inconsistent-return-statements,
+        useless-return,
+        consider-swap-variables,
+        consider-using-join,
+        consider-using-in,
+        consider-using-get,
+        chained-comparison,
+        consider-using-dict-comprehension,
+        consider-using-set-comprehension,
+        simplifiable-if-expression,
+        no-else-raise,
+        unnecessary-comprehension,
+        consider-using-sys-exit,
+        no-else-break,
+        no-else-continue,
+        super-with-arguments,
+        simplifiable-condition,
+        condition-evals-to-constant,
+        consider-using-generator,
+        use-a-generator,
+        consider-using-min-builtin,
+        consider-using-max-builtin,
+        consider-using-with,
+        unnecessary-dict-index-lookup,
+        use-list-literal,
+        use-dict-literal,
+        unnecessary-list-index-lookup,
+        use-yield-from,
+        duplicate-code,
+        cyclic-import,
+        consider-using-from-import,
+        http-response-with-json-dumps,
+        http-response-with-content-type-json,
+        redundant-content-type-for-json-response,
+        c-extension-no-member,
+        no-member
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins


### PR DESCRIPTION
Compare to #188.
Instead of fixing that old .pylintrc, start with a default generated one and change it into what we want.