### PR TITLE
refactor: improve DocumentTable types

### DIFF
--- a/client/components/DocumentTable.vue
+++ b/client/components/DocumentTable.vue
@@ -2,71 +2,73 @@
   <div>
     <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-600">
       <thead class="bg-gray-50 dark:bg-neutral-800">
-        <tr>
-          <th class="pl-3 w-9">&nbsp;</th>
-          <th
-            v-for="col of columns"
-            :key="col.key"
-            scope="col"
-            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-400"
-            :aria-sort="state.sortField === col.field ? state.sortDirection === 'asc' ? 'ascending' : 'descending' : undefined"
-          >
-            <button
-              v-if="col.sortable !== false && col.field"
-              class="bg-transparent border-none"
-              :aria-pressed="state.sortField === col.field"
-              @click.prevent="sortBy(col.field)">
-              <span>{{ col.label }}</span>
-              <template v-if="state.sortField === col.field">
-                <Icon v-if="state.sortDirection === 'asc'" name="uil:arrow-up" class="text-lg -mt-0.5" />
-                <Icon v-else-if="state.sortDirection === 'desc'" name="uil:arrow-down" class="text-lg -mt-0.5" />
-              </template>
-              <template v-else>
-                <!-- else render a placeholder icon see https://github.com/ietf-tools/rpc/issues/49 -->
-                <Icon
-                  name="uil:arrow-down"
-                  class="text-lg -mt-0.5 opacity-0"
-                />
-              </template>
-            </button>
-            <span v-else>{{ col.label }}</span>
-          </th>
-        </tr>
+      <tr>
+        <th class="pl-3 w-9">&nbsp;</th>
+        <th
+          v-for="col of columns"
+          :key="col.key"
+          scope="col"
+          class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-400"
+          :aria-sort="sortField === col.field ? sortDirection === 'asc' ? 'ascending' : 'descending' : undefined"
+        >
+          <button
+            v-if="col.sortable !== false && col.field"
+            class="bg-transparent border-none"
+            :aria-pressed="sortField === col.field"
+            @click.prevent="sortBy(col.field)">
+            <span>{{ col.label }}</span>
+            <template v-if="sortField === col.field">
+              <Icon v-if="sortDirection === 'asc'" name="uil:arrow-up" class="text-lg -mt-0.5"/>
+              <Icon v-else-if="sortDirection === 'desc'" name="uil:arrow-down" class="text-lg -mt-0.5"/>
+            </template>
+            <template v-else>
+              <!-- else render a placeholder icon see https://github.com/ietf-tools/rpc/issues/49 -->
+              <Icon
+                name="uil:arrow-down"
+                class="text-lg -mt-0.5 opacity-0"
+              />
+            </template>
+          </button>
+          <span v-else>{{ col.label }}</span>
+        </th>
+      </tr>
       </thead>
-      <tbody v-if="!loading" class="text-sm divide-y divide-gray-200 dark:divide-neutral-700 bg-white dark:bg-neutral-900">
-        <tr v-for="row of rows" :key="row.key">
-          <td class="pl-3">
-            <Icon name="uil:file-alt" size="1.25em" class="text-gray-400 dark:text-neutral-500" />
-          </td>
-          <td
-            v-for="col of columns"
-            :key="col.key"
-            :class="[
+      <tbody
+        v-if="!loading"
+        class="text-sm divide-y divide-gray-200 dark:divide-neutral-700 bg-white dark:bg-neutral-900">
+      <tr v-for="row of rows" :key="row[rowKey]">
+        <td class="pl-3">
+          <Icon name="uil:file-alt" size="1.25em" class="text-gray-400 dark:text-neutral-500"/>
+        </td>
+        <td
+          v-for="col of columns"
+          :key="col.key"
+          :class="[
               'px-3 py-4 text-gray-500 dark:text-neutral-400',
               col.classes && isFunction(col.classes) ? col.classes(col.field ? row[col.field] : row) : col.classes
             ]"
-          >
-            <component :is="buildCell(col, row)" />
-          </td>
-        </tr>
+        >
+          <component :is="buildCell(col, row)"/>
+        </td>
+      </tr>
       </tbody>
     </table>
     <div v-if="loading" class="w-full">
       <div class="h-0.5 w-full bg-emerald-100 dark:bg-emerald-900 overflow-hidden">
-        <div class="progress w-full h-full bg-emerald-500 left-right" />
+        <div class="progress w-full h-full bg-emerald-500 left-right"/>
       </div>
     </div>
     <div
       v-if="!data || data.length < 1"
       class="p-8 text-sm bg-white dark:bg-neutral-900 text-gray-500 dark:text-neutral-400"
     >
-      <Icon v-if="loading" name="ei:spinner-3" size="1.5em" class="animate-spin mr-2" />
+      <Icon v-if="loading" name="ei:spinner-3" size="1.5em" class="animate-spin mr-2"/>
       <em>{{ loading ? 'Fetching data...' : 'No documents to display.' }}</em>
     </div>
   </div>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="RowT extends Row & Record<RowKey, PropertyKey>, RowKey extends PropertyKey">
 import { RpcLabel, Icon, NuxtLink } from '#components'
 import { isArray, isFunction, orderBy } from 'lodash-es'
 import type { Column, Row } from './DocumentTableTypes'
@@ -76,12 +78,12 @@ const props = defineProps<{
   /**
    * Column definitions
    */
-  columns: Column[]
-  data: Record<string, unknown>[]
+  columns: Column<RowT>[]
+  data: RowT[]
   /**
    * The property to use as the unique key for each row
    */
-  rowKey: string
+  rowKey: RowKey
   /**
    * Whether to show the loading animation or not
    */
@@ -90,39 +92,39 @@ const props = defineProps<{
 
 // DATA
 
-const state = reactive<{
-  sortField: string
-  sortDirection: boolean | 'asc' | 'desc'
-}>({
-  sortField: '',
-  sortDirection: 'asc'
-})
+type SortDirection = 'asc' | 'desc'
 
-const rows = computed(() => {
+const sortField = ref<keyof RowT | null>(null)
+const sortDirection = ref<SortDirection>('asc')
+
+function getSortValue (row: RowT) {
+  return sortField.value ? row[sortField.value] : ''
+}
+
+const rows = computed<RowT[]>(() => {
   if (!props.data) { return [] }
-  const dataWithKey = props.data.map((row) => ({ ...row, key: row[props.rowKey] }))
-  if (state.sortField) {
-    return orderBy(dataWithKey, [state.sortField], [state.sortDirection])
+  if (sortField.value) {
+    return orderBy(props.data, getSortValue, [sortDirection.value])
   } else {
-    return dataWithKey
+    return props.data
   }
 })
 
 // METHODS
 
-function sortBy (fieldName: string) {
-  if (state.sortField === fieldName) {
-    state.sortDirection = state.sortDirection === 'asc' ? 'desc' : 'asc'
+function sortBy (fieldName: keyof RowT) {
+  if (sortField.value === fieldName) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
   } else {
-    state.sortDirection = 'asc'
+    sortDirection.value = 'asc'
   }
-  state.sortField = fieldName
+  sortField.value = fieldName
 }
 
 /**
  * Build cell node
  */
-function buildCell (col: Column, row: Row) {
+function buildCell (col: Column<RowT>, row: RowT) {
   const value = col.field ? row[col.field] : null
   const values = isArray(value) ? value : [value]
   const formattedValues = col.format
@@ -181,7 +183,7 @@ function buildCell (col: Column, row: Row) {
 /**
  * Handle labels array in either string or object format
  */
-function transformLabels (val: string[], defaultColor: ColorEnum): Label[] {
+function transformLabels (val: (string | Label)[], defaultColor: ColorEnum): Label[] {
   return val.map((item): Label => {
     if (typeof item === 'string') {
       return {
@@ -190,7 +192,7 @@ function transformLabels (val: string[], defaultColor: ColorEnum): Label[] {
         color: defaultColor
       }
     } else {
-      return item as Label
+      return item
     }
   })
 }
@@ -203,8 +205,9 @@ function transformLabels (val: string[], defaultColor: ColorEnum): Label[] {
 }
 
 .left-right {
-  transform-origin: 0% 50%;
+  transform-origin: 0 50%;
 }
+
 @keyframes progress {
   0% {
     transform: translateX(0) scaleX(0);
@@ -229,10 +232,16 @@ The `columns` property is an arrow of objects with the following possible option
 | `label` | *String* | Column title | ✅ |
 | `field` | *String* | Row property to use / sort on | ✅ |
 | `format` | *Function* | Optional lambda function to transform the cell value. e.g. `(val) => val.toLowerCase()` |
-| `link` | *Function* | Lambda function that returns a URL. The value will be displayed as clickable link. `(row, val) => val.personUrl` |
-| `icon` | *String* | If defined, the name of the icon to display to the left of the value. See the [Iconify reference](https://icon-sets.iconify.design/) for all possible options. |
-| `labels` | *Array \| Function* | Either an array or a lambda function (e.g. `row => row.labels`) that return an array of / a mix of:<br>- strings *(the `labelDefaultColor` will be used)*<br>- an object `{ label: 'something', color: 'rose' }` |
-| `labelDefaultColor` | *String* | The fallback color name to use for a label when not explicitly provided. Any of the [TailwindCSS color names](https://tailwindcss.com/docs/customizing-colors), in lowercase. e.g. `purple` |
-| `classes` | *String \| Function* | List of space separated CSS classes to apply to the cell, or a lambda function e.g. `(row) => row.fooBar` |
+| `link` | *Function* | Lambda function that returns a URL. The value will be displayed as clickable link. `(row, val)
+=> val.personUrl` |
+| `icon` | *String* | If defined, the name of the icon to display to the left of the value. See the [Iconify
+reference](https://icon-sets.iconify.design/) for all possible options. |
+| `labels` | *Array \| Function* | Either an array or a lambda function (e.g. `row => row.labels`) that return an array
+of / a mix of:<br>- strings *(the `labelDefaultColor` will be used)*<br>- an object `{ label: 'something', color: 'rose'
+}` |
+| `labelDefaultColor` | *String* | The fallback color name to use for a label when not explicitly provided. Any of the
+[TailwindCSS color names](https://tailwindcss.com/docs/customizing-colors), in lowercase. e.g. `purple` |
+| `classes` | *String \| Function* | List of space separated CSS classes to apply to the cell, or a lambda function e.g.
+`(row) => row.fooBar` |
 | `sortable` | *Boolean* | Whether the column can be sorted or not. Defaults to `true`. | |
 </docs>

--- a/client/components/DocumentTable.vue
+++ b/client/components/DocumentTable.vue
@@ -150,24 +150,26 @@ function buildCell (col: Column<RowT>, row: RowT) {
       cssClasses.push('flex items-center')
     }
 
-    if (isFunction(col.link)) {
-      children.push(h(NuxtLink, {
-        class: [
-          ...cssClasses,
-          'text-violet-900 hover:text-violet-500 dark:text-violet-300 hover:dark:text-violet-100'
-        ],
-        to: col.link(row, val)
-      }, () => contents))
-    } else {
-      children.push(h('span', {
-        class: cssClasses
-      }, contents.map(val => {
-        return val
-      })))
-    }
+    if (!isFunction(col.labels)) {
+      if (isFunction(col.link)) {
+        children.push(h(NuxtLink, {
+          class: [
+            ...cssClasses,
+            'text-violet-900 hover:text-violet-500 dark:text-violet-300 hover:dark:text-violet-100'
+          ],
+          to: col.link(row, val)
+        }, () => contents))
+      } else {
+        children.push(h('span', {
+          class: cssClasses
+        }, contents.map(val => {
+          return val
+        })))
+      }
 
-    if (idx < formattedValuesArray.length - 1) {
-      children.push(h('span', ', '))
+      if (idx < formattedValuesArray.length - 1) {
+        children.push(h('span', ', '))
+      }
     }
   }
 

--- a/client/components/DocumentTableTypes.ts
+++ b/client/components/DocumentTableTypes.ts
@@ -1,25 +1,20 @@
 import type { VNode } from 'vue'
-import type { ColorEnum } from '~/rpctracker_client'
+import type { ColorEnum, Label } from '~/rpctracker_client'
 
 export type Value = unknown
 
 export type Row = Record<string, Value>
 
-export interface Column {
-  key: string
+export interface Column<RowT extends Row> {
+  key: keyof RowT
   label: string
-  labels?: (row: Row) => string[]
+  labels?: (row: RowT) => (Label | string)[]
   labelDefaultColor?: ColorEnum
-  field?: string
+  field?: keyof RowT
   classes?: string | ((val: Value) => string)
   sortable?: boolean
-  link?: string | ((row: Row, val: Value) => string)
+  link?: string | ((row: RowT, val: Value) => string)
   formatType?: 'all'
   format?: (value: Value) => VNode | VNode[] | string
   icon?: string
-}
-
-export interface Table {
-  columns: Column[]
-  rows: Row[]
 }

--- a/client/pages/auth48/[section].vue
+++ b/client/pages/auth48/[section].vue
@@ -117,7 +117,7 @@ const docs = computed(() => {
 // DATA
 
 const columns = computed(() => {
-  const cols: Column[] = [
+  const cols: Column<typeof docs.value[number]>[] = [
     {
       key: 'ed',
       label: 'Managing Editor',

--- a/client/pages/docs/index.vue
+++ b/client/pages/docs/index.vue
@@ -14,7 +14,7 @@
     <div class="mt-8 flow-root">
       <DocumentTable
         :columns="columns"
-        :data="myAssignments.map(a => ({ ...a.rfcToBe })).filter(row => !!row)"
+        :data="tableRows"
         row-key="id"
         :loading="pending"
       />
@@ -37,11 +37,17 @@ const myAssignments = computed(() => allAssignments.value?.filter(
   (a) => ({ ...a, rfcToBe: allDocuments.value?.find(d => d.id === a.rfcToBe) })
 ))
 
+const tableRows = computed(() => myAssignments.value.map(a => ({ ...a.rfcToBe })).filter(row => !!row))
+
 const pending = computed(() => assignmentsPending.value || documentsPending.value)
 
 // DATA
 
-const columns: Column[] = [
+function findLabel (labelId: number) {
+  return labels.value.find((lbl) => lbl.id === labelId) ?? ''
+}
+
+const columns: Column<typeof tableRows.value[number]>[] = [
   {
     key: 'name',
     label: 'Document',
@@ -54,8 +60,10 @@ const columns: Column[] = [
     key: 'labels',
     label: 'Labels',
     labels: row => {
-      // @ts-ignore
-      return row.labels.map(lblId => labels.value.find(lbl => lbl.id === lblId)) || []
+      if (row.labels) {
+        return row.labels.map(findLabel)
+      }
+      return []
     }
   }
 ]

--- a/client/pages/queue/[section].vue
+++ b/client/pages/queue/[section].vue
@@ -99,7 +99,8 @@ const { data: people } = await useAsyncData(
 )
 
 const columns = computed(() => {
-  const cols: Column[] = [
+  // todo: actually work out the typing of the columns
+  const cols: Column<typeof filteredDocuments.value[number]>[] = [
     {
       key: 'name',
       label: 'Document',


### PR DESCRIPTION
This is an attempt to clean up some type complaints in the DocumentTable. It clears up all the complaints I see in DocumentTable.vue itself. Unfortunately the actual places the component is used are either seeing an `any` type or are confused because the `id` field is shown as possibly undefined due to limitations in the Django API generation. I'm hoping to clear those up eventually.

Also fixes a minor bug in the `labels` column where the ID was being displayed beside each label.

Best to look at the diffs with whitespace changes suppressed because some reformatting got mixed in - sorry about that.