### PR TITLE
ci: declare vite deps

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -55,6 +55,15 @@ export default defineNuxtConfig({
         }
       }
     },
+    optimizeDeps: {
+      // Deps that vite does not detect statically
+      include: [
+        'lodash-es',
+        'luxon',
+        'humanize-duration',
+        'vue3-snackbar'
+      ]
+    },
     plugins: [
       {
         name: 'vue-docs',


### PR DESCRIPTION
Avoids a round of optimize/reload on the first run and fixes an issue where vue3-snackbar is optimized but not reloaded, requiring manual restart of the dev server to work around.