### PR TITLE
feat: version/dumpinfo mgmt and api

### DIFF
--- a/purple/urls.py
+++ b/purple/urls.py
@@ -80,5 +80,6 @@ urlpatterns = [
     path("api/rpc/submissions/", rpc_api.submissions),
     path("api/rpc/submissions/<int:document_id>/", rpc_api.submission),
     path("api/rpc/submissions/<int:document_id>/import/", rpc_api.import_submission),
+    path("api/rpc/version/", rpc_api.version),
     path("api/rpc/", include(router.urls)),
 ]

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -8,9 +8,7 @@ from rest_framework.decorators import (
     action,
     api_view,
     permission_classes,
-    authentication_classes,
 )
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework import serializers

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -51,7 +51,15 @@ from .serializers import (
     StdLevelNameSerializer,
     StreamNameSerializer,
     TlpBoilerplateChoiceNameSerializer,
+    VersionInfoSerializer,
 )
+from .utils import VersionInfo
+
+
+@api_view(["GET"])
+def version(request):
+    """Get application version information"""
+    return JsonResponse(VersionInfoSerializer(VersionInfo()).data)
 
 
 @api_view(["GET"])

--- a/rpc/management/commands/add_dumpinfo.py
+++ b/rpc/management/commands/add_dumpinfo.py
@@ -1,0 +1,13 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+
+from ...models import DumpInfo
+
+
+class Command(BaseCommand):
+    help = "Add DumpInfo instance with the current time"
+
+    def handle(self, *args, **options):
+        dumpinfo = DumpInfo.objects.create(timestamp=now())
+        self.stdout.write(f"Set database dump timestamp to {dumpinfo.timestamp}")

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -29,6 +29,13 @@ from .models import (
 )
 
 
+class VersionInfoSerializer(serializers.Serializer):
+    """Serialize version information"""
+
+    version = serializers.CharField(read_only=True)
+    dump_timestamp = serializers.DateTimeField(required=False, read_only=True)
+
+
 class UserSerializer(serializers.Serializer):
     """Serialize a User record"""
 

--- a/rpc/utils.py
+++ b/rpc/utils.py
@@ -1,8 +1,20 @@
-# Copyright The IETF Trust 2023, All Rights Reserved
+# Copyright The IETF Trust 2023-2024, All Rights Reserved
 # -*- coding: utf-8 -*-
 from django.db.models import Max
 
-from .models import RfcToBe, UnusableRfcNumber
+from .models import RfcToBe, UnusableRfcNumber, DumpInfo
+
+
+class VersionInfo:
+    """Application version information model"""
+
+    version = "version-access-not-yet-implemented"
+
+    def __init__(self):
+        # If we have a DumpInfo, populate the dump_timestamp property
+        dumpinfo = DumpInfo.objects.order_by("-timestamp").first()
+        if dumpinfo is not None:
+            self.dump_timestamp = dumpinfo.timestamp
 
 
 def next_rfc_number(count=1) -> list[int]:


### PR DESCRIPTION
This adds a management command to create a `DumpInfo` with a timestamp and adds a stub of a version API at `/api/rpc/version/`. That does not currently provide useful version info, but includes the dump timestamp when it's available.