### PR TITLE
ci: celery+rabbitmq for staging dt

### DIFF
--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -138,8 +138,43 @@ spec:
             - name: dt-cfg
               mountPath: /workspace/ietf/settings_local.py
               subPath: datatracker-settings_local.py
+        # -----------------------------------------------------
+        # Celery Container
+        # -----------------------------------------------------
+        - name: celery
+          image: "ghcr.io/ietf-tools/datatracker:feat-rpc-api-latest"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: dt-vol
+              mountPath: /a
+            - name: celery-tmp
+              mountPath: /tmp
+            - name: celery-home
+              mountPath: /home/datatracker
+            - name: celery-xml2rfc-cache
+              mountPath: /var/cache/xml2rfc
+            - name: dt-cfg
+              mountPath: /workspace/ietf/settings_local.py
+              subPath: settings_local.py
+          env:
+            - name: "CONTAINER_ROLE"
+              value: "celery"
+          envFrom:
+            - secretRef:
+                name: dt-secrets-env
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 1000
       volumes:
-        # To be overriden with the actual shared volume
         - name: dt-vol
           emptyDir:
             sizeLimit: "2Gi"
@@ -150,6 +185,15 @@ spec:
           emptyDir:
             sizeLimit: "2Gi"
         - name: dt-home
+          emptyDir:
+            sizeLimit: "2Gi"
+        - name: celery-tmp
+          emptyDir:
+            sizeLimit: "2Gi"
+        - name: celery-xml2rfc-cache
+          emptyDir:
+            sizeLimit: "2Gi"
+        - name: celery-home
           emptyDir:
             sizeLimit: "2Gi"
         - name: dt-cfg
@@ -175,3 +219,176 @@ spec:
       name: http
   selector:
     app: datatracker
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        # -----------------------------------------------------
+        # RabbitMQ Container
+        # -----------------------------------------------------
+        - image: "ghcr.io/ietf-tools/datatracker-mq:3.12-alpine"
+          imagePullPolicy: Always
+          name: rabbitmq
+          ports:
+            - name: amqp
+              containerPort: 5672
+              protocol: TCP
+          volumeMounts:
+            - name: rabbitmq-data
+              mountPath: /var/lib/rabbitmq
+              subPath: "rabbitmq"
+            - name: rabbitmq-tmp
+              mountPath: /tmp
+            - name: rabbitmq-config
+              mountPath: "/etc/rabbitmq"
+          env:
+            - name: CELERY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: purple-secrets-env
+                  key: CELERY_PASSWORD
+          livenessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "-q", "ping"]
+            periodSeconds: 30
+            timeoutSeconds: 5
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 60
+            exec:
+              command: ["rabbitmq-diagnostics", "-q", "ping"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            # rabbitmq image sets up uid/gid 100/101
+            runAsUser: 100
+            runAsGroup: 101
+      initContainers:
+        # -----------------------------------------------------
+        # Init RabbitMQ data
+        # -----------------------------------------------------
+        - name: init-rabbitmq
+          image: busybox:stable
+          command:
+            - "sh"
+            - "-c"
+            - "mkdir -p -m700 /mnt/rabbitmq && chown 100:101 /mnt/rabbitmq"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "rabbitmq-data"
+              mountPath: "/mnt"
+      volumes:
+        # This is a persistent volume in prod, but no need to persist for this project.
+        - name: rabbitmq-data
+          emptyDir:
+            sizeLimit: "2Gi"
+        - name: rabbitmq-tmp
+          emptyDir:
+            sizeLimit: "50Mi"
+        - name: rabbitmq-config
+          configMap:
+            name: "rabbitmq-configmap"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-configmap
+data:
+  definitions.json: |-
+    {
+      "permissions": [
+        {
+          "configure": ".*",
+          "read": ".*",
+          "user": "datatracker",
+          "vhost": "dt",
+          "write": ".*"
+        }
+      ],
+      "users": [
+        {
+          "hashing_algorithm": "rabbit_password_hashing_sha256",
+          "limits": {},
+          "name": "datatracker",
+          "password_hash": "HJxcItcpXtBN+R/CH7dUelfKBOvdUs3AWo82SBw2yLMSguzb",
+          "tags": []
+        }
+      ],
+      "vhosts": [
+        {
+          "limits": [],
+          "metadata": {
+            "description": "",
+            "tags": []
+          },
+          "name": "dt"
+        }
+      ]
+    }
+  rabbitmq.conf: |-
+    # prevent guest from logging in over tcp
+    loopback_users.guest = true
+
+    # load saved definitions
+    load_definitions = /etc/rabbitmq/definitions.json
+
+    # Ensure that enough disk is available to flush to disk. To do this, need to limit the
+    # memory available to the container to something reasonable. See
+    # https://www.rabbitmq.com/production-checklist.html#monitoring-and-resource-usage
+    # for recommendations.
+
+    # 1-1.5 times the memory available to the container is adequate for disk limit
+    disk_free_limit.absolute = 6000MB
+
+    # This should be ~40% of the memory available to the container. Use an
+    # absolute number because relative will be proprtional to the full machine
+    # memory.
+    vm_memory_high_watermark.absolute = 1600MB
+
+    # Logging
+    log.file = false
+    log.console = true
+    log.console.level = info
+    log.console.formatter = json
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  type: ClusterIP
+  clusterIP: None  # headless service
+  ports:
+    - port: 5672
+      targetPort: amqp
+      protocol: TCP
+      name: amqp
+  selector:
+    app: rabbitmq


### PR DESCRIPTION
Adds a celery container to the datatracker-rpc deployment and a rabbitmq statefulset.

The celery container is handled differently from production, where it has its own deployment, because this makes it easier to have a shared volume. For now we don't need (or want) the data on that volume to persist across refreshes anyway. We'll probably need to revisit this arrangement if/when we start doing things that need a populated shared volume.