### PR TITLE
feat: enable django admin, add models to admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ __pycache__
 /rpcapi.yaml
 /openapi/rpcapi_client
 /docker/docker-compose.extend-custom.yml
+client/purple_client
+purple/static
+purple_api.yaml
+.devcontainer/docker-compose.extend-custom.yml

--- a/datatracker/admin.py
+++ b/datatracker/admin.py
@@ -1,3 +1,10 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+
 from django.contrib import admin
 
-# Register your models here.
+from .models import DatatrackerPerson, Document, DocumentLabel
+
+
+admin.site.register(DatatrackerPerson)
+admin.site.register(Document)
+admin.site.register(DocumentLabel)

--- a/purple/settings/base.py
+++ b/purple/settings/base.py
@@ -142,6 +142,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "static"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/rpc/admin.py
+++ b/rpc/admin.py
@@ -1,3 +1,56 @@
-from django.contrib import admin
+# Copyright The IETF Trust 2025, All Rights Reserved
 
-# Register your models here.
+from django.contrib import admin
+from .models import (
+    DumpInfo,
+    RpcPerson,
+    RfcToBeLabel,
+    RfcToBe,
+    DispositionName,
+    SourceFormatName,
+    StdLevelName,
+    TlpBoilerplateChoiceName,
+    StreamName,
+    DocRelationshipName,
+    ClusterMember,
+    Cluster,
+    UnusableRfcNumber,
+    RpcRole,
+    Capability,
+    Assignment,
+    RfcAuthor,
+    AdditionalEmail,
+    FinalApproval,
+    IanaAction,
+    ActionHolder,
+    RpcRelatedDocument,
+    RpcDocumentComment,
+    Label,
+    RpcAuthorComment,
+)
+
+admin.site.register(DumpInfo)
+admin.site.register(RpcPerson)
+admin.site.register(RfcToBeLabel)
+admin.site.register(RfcToBe)
+admin.site.register(DispositionName)
+admin.site.register(SourceFormatName)
+admin.site.register(StdLevelName)
+admin.site.register(TlpBoilerplateChoiceName)
+admin.site.register(StreamName)
+admin.site.register(DocRelationshipName)
+admin.site.register(ClusterMember)
+admin.site.register(Cluster)
+admin.site.register(UnusableRfcNumber)
+admin.site.register(RpcRole)
+admin.site.register(Capability)
+admin.site.register(Assignment)
+admin.site.register(RfcAuthor)
+admin.site.register(AdditionalEmail)
+admin.site.register(FinalApproval)
+admin.site.register(IanaAction)
+admin.site.register(ActionHolder)
+admin.site.register(RpcRelatedDocument)
+admin.site.register(RpcDocumentComment)
+admin.site.register(Label)
+admin.site.register(RpcAuthorComment)


### PR DESCRIPTION
what was done:
- on login to purple, grant Admin permission if DT user's role tuple ["leadmaintainer", "tools"] is set

still to do:
- build static files for dev and prod (run `./manage.py collectstatic`) - needs currently to be done manually
- discuss proper permissions to a) access purple, b) access Django admin

