### PR TITLE
fix: Allow API access only to authenticated users

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -9,7 +9,6 @@ from rest_framework.decorators import (
     api_view,
     permission_classes,
 )
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import mixins, views, viewsets
@@ -61,7 +60,6 @@ def version(request):
 
 
 @api_view(["GET"])
-@permission_classes([AllowAny])
 def profile(request):
     """Get profile of current user"""
     user = request.user
@@ -288,8 +286,6 @@ class RpcRoleViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class StatsLabels(views.APIView):
-    permission_classes = [AllowAny]
-
     @extend_schema(
         operation_id="stats_labels",
         responses=inline_serializer(


### PR DESCRIPTION
This restricts access to authenticated users.
Default setting is[^1]:
```
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
```

PR #274 seems to address the UI part of this.

[^1]: https://github.com/ietf-tools/purple/blob/main/purple/settings/base.py#L89-L91