### PR TITLE
feat: RP-initiated logout from OIDC provider

### DIFF
--- a/purple/settings/__init__.py
+++ b/purple/settings/__init__.py
@@ -3,10 +3,10 @@
 
 import os
 
-deployment_mode = os.environ.get("PURPLE_DEPLOYMENT_MODE", "production")
-if deployment_mode == "development":
+DEPLOYMENT_MODE = os.environ.get("PURPLE_DEPLOYMENT_MODE", "production")
+if DEPLOYMENT_MODE == "development":
     from .development import *
-elif deployment_mode == "build":
+elif DEPLOYMENT_MODE == "build":
     from .build import *
 else:
     from .production import *

--- a/purple/settings/base.py
+++ b/purple/settings/base.py
@@ -73,6 +73,9 @@ AUTHENTICATION_BACKENDS = (
 # OIDC configuration (see also production.py/development.py)
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = "openid profile roles"
+OIDC_STORE_ID_TOKEN = True  # store id_token in session (used for RP-initiated logout)
+ALLOW_LOGOUT_GET_METHOD = True  # for now anyway
+OIDC_OP_LOGOUT_URL_METHOD = "rpcauth.utils.op_logout_url"
 
 # How often to renew tokens? Default is 15 minutes. Needs SessionRefresh middleware.
 # OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 15 * 60

--- a/purple/settings/development.py
+++ b/purple/settings/development.py
@@ -28,7 +28,7 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = (
 )
 OIDC_OP_TOKEN_ENDPOINT = "http://host.docker.internal:8000/api/openid/token/"
 OIDC_OP_USER_ENDPOINT = "http://host.docker.internal:8000/api/openid/userinfo/"
-
+OIDC_OP_END_SESSION_ENDPOINT = "http://localhost:8000/api/openid/end-session/"
 
 # Misc
 SESSION_COOKIE_NAME = (

--- a/purple/settings/production.py
+++ b/purple/settings/production.py
@@ -55,6 +55,9 @@ OIDC_OP_TOKEN_ENDPOINT = os.environ.get(
 OIDC_OP_USER_ENDPOINT = os.environ.get(
     "PURPLE_OIDC_OP_USER_ENDPOINT", f"{OIDC_OP_ISSUER_ID}/userinfo/"
 )
+OIDC_OP_END_SESSION_ENDPOINT = os.environ.get(
+    "PURPLE_OIDC_OP_END_SESSION_ENDPOINT", f"{OIDC_OP_ISSUER_ID}/end-session/"
+)
 
 
 # Config for Cloudflare service token auth

--- a/rpcauth/utils.py
+++ b/rpcauth/utils.py
@@ -1,0 +1,46 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+import warnings
+from urllib.parse import urlsplit, parse_qsl, urlunsplit, urlencode
+
+from django.conf import settings
+
+
+def op_logout_url(request):
+    """Construct URI for initiating logout from OIDC provider"""
+    end_session_endpoint = getattr(settings, "OIDC_OP_END_SESSION_ENDPOINT", None)
+    logout_redirect_url = getattr(settings, "LOGOUT_REDIRECT_URL", "/")
+    if end_session_endpoint is None:
+        # No END_SESSION_ENDPOINT is configured so we can't initiate an OP logout
+        return logout_redirect_url
+
+    # Per the OIDC spec, end_session_endpoint can include a query string of
+    # its own, so parse and preserve it and append our parameters to the end.
+    # https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+    endpoint_parts = urlsplit(end_session_endpoint)
+
+    if settings.DEPLOYMENT_MODE == "production" and endpoint_parts.scheme != "https":
+        warnings.warn(
+            "OIDC_OP_END_SESSION_ENDPOINT must be an https URI. Not initiating logout from OP."
+        )
+        return logout_redirect_url
+
+    query_params = parse_qsl(endpoint_parts.query)
+    # make sure the URL did not already contain any of the params we are about to use
+    if any(
+        name in ["client_id", "post_logout_redirect_url", "id_token_hint"]
+        for name, _ in query_params
+    ):
+        warnings.warn(
+            "OIDC_OP_END_SESSION_ENDPOINT has an inappropriate query param. Not initiating logout from OP."
+        )
+        return logout_redirect_url
+
+    # Construct the end-session URL
+    query_params.append(
+        ("post_logout_redirect_uri", request.build_absolute_uri(logout_redirect_url)),
+    )
+    # hint with the id token if we have it
+    id_token = request.session.get("oidc_id_token", None)
+    if id_token is not None:
+        query_params.append(("id_token_hint", id_token))
+    return urlunsplit(endpoint_parts._replace(query=urlencode(query_params)))

--- a/rpcauth/views.py
+++ b/rpcauth/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
Configures mozilla-django-oidc to end the session with the OIDC provider (OP) after ending the local session. Until front end support is added, this can be exercised manually by visiting `/oidc/logout/`.

The OP is instructed to redirect to purple's root path after ending the OP session. In order for this to work, the OIDC client in the datatracker needs to be edited to add this to the `post_logout_redirect_uris` list. This can be done from the admin for dev until we update the database image action. We'll need to do it manually for production.