### PR TITLE
refactor: improve fetching my documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ __pycache__
 client/purple_client
 purple/static
 purple_api.yaml
-.devcontainer/docker-compose.extend-custom.yml
+

--- a/client/pages/docs/index.vue
+++ b/client/pages/docs/index.vue
@@ -50,11 +50,18 @@ const columns: Column[] = [
   }
 ]
 
-const { data: myAssignments } = await useAsyncData(
+const { data: myAssignments, status: assignmentStatus } = await useAsyncData(
   'myAssignments',
-  () => api.assignmentsList(),
+  async () => {
+    if (userStore.rpcPersonId === null) {
+      return []
+    }
+    return api.rpcPersonAssignmentsList({ personId: userStore.rpcPersonId })
+  },
   { server: false, default: () => ([]) }
 )
+
+const pending = computed(() => assignmentStatus.value === 'pending')
 
 const { data: labels } = await useAsyncData(
   'labels',

--- a/client/pages/docs/index.vue
+++ b/client/pages/docs/index.vue
@@ -29,16 +29,6 @@ import type { Column } from '~/components/DocumentTableTypes'
 const api = useApi()
 const userStore = useUserStore()
 
-// COMPUTED
-
-const myAssignments = computed(() => allAssignments.value?.filter(
-  (a) => a.person === userStore.rpcPersonId
-).map(
-  (a) => ({ ...a, rfcToBe: allDocuments.value?.find(d => d.id === a.rfcToBe) })
-))
-
-const pending = computed(() => assignmentsPending.value || documentsPending.value)
-
 // DATA
 
 const columns: Column[] = [
@@ -60,15 +50,9 @@ const columns: Column[] = [
   }
 ]
 
-const { data: allAssignments, pending: assignmentsPending } = await useAsyncData(
-  'allAssignments',
-  () => api.rpcPersonAssignmentsList({ personId: userStore.rpcPersonId }),
-  { server: false, default: () => ([]) }
-)
-
-const { data: allDocuments, pending: documentsPending } = await useAsyncData(
-  'allDocuments',
-  () => api.documentsList(),
+const { data: myAssignments } = await useAsyncData(
+  'myAssignments',
+  () => api.assignmentsList(),
   { server: false, default: () => ([]) }
 )
 

--- a/rpc/admin.py
+++ b/rpc/admin.py
@@ -34,7 +34,7 @@ admin.site.register(DumpInfo)
 
 class RpcPersonAdmin(admin.ModelAdmin):
     search_fields = ["datatracker_person__datatracker_id"]
-    list_display = ["datatracker_person", "can_hold_role__name"]
+    list_display = ["id", "datatracker_person", "can_hold_role__name"]
 
 
 admin.site.register(RpcPerson, RpcPersonAdmin)
@@ -66,7 +66,14 @@ class RpcRoleAdmin(admin.ModelAdmin):
 
 admin.site.register(RpcRole, RpcRoleAdmin)
 admin.site.register(Capability)
-admin.site.register(Assignment)
+
+
+class AssignmentAdmin(admin.ModelAdmin):
+    search_fields = ["person__datatracker_person__datatracker_id"]
+    list_display = ["id", "rfc_to_be", "person", "role", "state"]
+
+
+admin.site.register(Assignment, AssignmentAdmin)
 
 
 class RfcAuthorAdmin(admin.ModelAdmin):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -50,6 +50,7 @@ from .serializers import (
     StreamNameSerializer,
     TlpBoilerplateChoiceNameSerializer,
     VersionInfoSerializer,
+    UserSerializer,
 )
 from .utils import VersionInfo
 
@@ -263,6 +264,20 @@ class ClusterViewSet(viewsets.ReadOnlyModelViewSet):
 class AssignmentViewSet(viewsets.ModelViewSet):
     queryset = Assignment.objects.all()
     serializer_class = AssignmentSerializer
+
+    def get_queryset(self):
+
+        user = self.request.user
+
+        person_id = UserSerializer().get_person_id(user)
+
+        if person_id is None:
+            return Assignment.objects.none()
+
+        # Filter assignments for the logged-in RpcPerson
+        return Assignment.objects.filter(person_id=person_id).select_related(
+            "rfc_to_be"
+        )
 
 
 class RfcToBeViewSet(viewsets.ModelViewSet):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -52,6 +52,7 @@ from .serializers import (
     TlpBoilerplateChoiceNameSerializer,
     VersionInfoSerializer,
     UserSerializer,
+    check_user_has_role,
 )
 from .utils import VersionInfo
 
@@ -147,7 +148,7 @@ class RpcPersonAssignmentViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
 
         queryset = super().get_queryset().filter(person_id=req_person_id)
 
-        is_manager = UserSerializer().has_role(user, "manager")
+        is_manager = check_user_has_role(user, "manager")
         if user.is_superuser or is_manager:
             return queryset
 
@@ -285,7 +286,7 @@ class AssignmentViewSet(viewsets.ModelViewSet):
 
         base_queryset = super().get_queryset()
 
-        is_manager = UserSerializer().has_role(user, "manager")
+        is_manager = check_user_has_role(user, "manager")
         if user.is_superuser or is_manager:
             return base_queryset
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -56,14 +56,6 @@ class UserSerializer(serializers.Serializer):
             return rpc_person.pk
         return None
 
-    def has_role(self, user, role) -> Optional[RpcPerson]:
-        rpc_person = RpcPerson.objects.filter(
-            datatracker_person=user.datatracker_person()
-        ).first()
-        if rpc_person:
-            return rpc_person.can_hold_role.filter(slug=role).exists()
-        return None
-
 
 @dataclass
 class HistoryRecord:
@@ -551,3 +543,12 @@ class SubmissionListItemSerializer(serializers.Serializer):
     name = serializers.CharField()
     stream = serializers.CharField()
     submitted = serializers.DateTimeField()
+
+
+def check_user_has_role(user, role) -> Optional[bool]:
+    rpc_person = RpcPerson.objects.filter(
+        datatracker_person=user.datatracker_person()
+    ).first()
+    if rpc_person:
+        return rpc_person.can_hold_role.filter(slug=role).exists()
+    return None

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -336,6 +336,8 @@ class ActionHolderSerializer(serializers.ModelSerializer):
 
 
 class AssignmentSerializer(serializers.ModelSerializer):
+    rfc_to_be = RfcToBeSerializer(read_only=True)
+
     class Meta:
         model = Assignment
         fields = [

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -56,6 +56,14 @@ class UserSerializer(serializers.Serializer):
             return rpc_person.pk
         return None
 
+    def has_role(self, user, role) -> Optional[RpcPerson]:
+        rpc_person = RpcPerson.objects.filter(
+            datatracker_person=user.datatracker_person()
+        ).first()
+        if rpc_person:
+            return rpc_person.can_hold_role.filter(slug=role).exists()
+        return None
+
 
 @dataclass
 class HistoryRecord:

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -545,10 +545,10 @@ class SubmissionListItemSerializer(serializers.Serializer):
     submitted = serializers.DateTimeField()
 
 
-def check_user_has_role(user, role) -> Optional[bool]:
+def check_user_has_role(user, role) -> bool:
     rpc_person = RpcPerson.objects.filter(
         datatracker_person=user.datatracker_person()
     ).first()
     if rpc_person:
         return rpc_person.can_hold_role.filter(slug=role).exists()
-    return None
+    return False

--- a/rpcauth/admin.py
+++ b/rpcauth/admin.py
@@ -4,4 +4,9 @@ from django.contrib.auth.admin import UserAdmin
 from .models import User
 
 
+class UserAdmin(admin.ModelAdmin):
+    search_fields = ["name", "username", "datatracker_subject_id"]
+    list_display = ["name", "username", "datatracker_subject_id"]
+
+
 admin.site.register(User, UserAdmin)


### PR DESCRIPTION
Backend: 
new behavior: 
- only assignments of currently authenticated user are returned for endpoints `GET /api/rpc/assignments` 
- assignments in payload also contain embedded data of related RfcToBe

Frontend:
Improve API calls on page "My Documents (Documents assigned to me)", requesting all documents and all assignments and intersecting is no longer required