### PR TITLE
feat: stricter CSP configuration

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -41,7 +41,7 @@ export default defineNuxtConfig({
       contentSecurityPolicy: {
         'img-src': [
           "'self'",
-          "'data:'",
+          'data:',
           '*.ietf.org'
         ],
         'script-src': [

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -45,9 +45,6 @@ export default defineNuxtConfig({
           '*.ietf.org'
         ],
         'script-src': [
-          "'self'",
-          'https:',
-          // "'unsafe-inline'", ignored because nonce is present; could uncomment to support old browsers
           "'strict-dynamic'",
           "'nonce-{{nonce}}'",
           // hash to allow inline script for the "warning" frame injected in staging

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -51,9 +51,7 @@ export default defineNuxtConfig({
         ],
         'script-src': [
           "'strict-dynamic'",
-          "'nonce-{{nonce}}'",
-          // hash to allow inline script for the "warning" frame injected in staging
-          "'sha256-9d0wX/zjSHgriLlZ2/0kuEndnxQOqKv/OCur9Ty3CGM='"
+          "'nonce-{{nonce}}'"
         ]
       }
     }

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -34,6 +34,11 @@ export default defineNuxtConfig({
     credits: false,
     disallow: ['/']
   },
+  runtimeConfig: {
+    public: {
+      cspScriptSrcHashes: '' // comma-separated list
+    }
+  },
   security: {
     // adjusts the defaults, see
     // https://nuxt-security.vercel.app/getting-started/configuration#defaults

--- a/client/server/plugins/runtimeCspPlugin.ts
+++ b/client/server/plugins/runtimeCspPlugin.ts
@@ -1,0 +1,30 @@
+// Copyright The IETF Trust 2025, All Rights Reserved
+import defu from 'defu'
+
+export default defineNitroPlugin((nitroApp) => {
+  // Plugin to augment the build-time nuxt-security configuration with runtime values
+  // See https://nuxt-security.vercel.app/advanced/hooks, particularly the examples
+  nitroApp.hooks.hook(
+    'nuxt-security:routeRules',
+    async (appSecurityOptions) => {
+      const runtimeConfig = useRuntimeConfig()
+      const scriptSrcHashes = runtimeConfig.public?.cspScriptSrcHashes
+        ?.split(',')
+        .map(h => `'${h.trim()}'`)
+        .filter(s => s !== "''") // exclude empty entries
+      if (scriptSrcHashes) {
+        // defu() will add the hashes to the existing script-src array in the security options
+        appSecurityOptions['/**'] = defu(
+          {
+            headers: {
+              contentSecurityPolicy: {
+                'script-src': scriptSrcHashes
+              }
+            }
+          },
+          appSecurityOptions['/**']
+        )
+      }
+    }
+  )
+})


### PR DESCRIPTION
Removes the hard-coded script-src hash from nuxt-security's CSP configuration in nuxt.config.ts. This was added to allow execution of the script injected with the "WARNING" frame that we apply to staging/dev instances.

Instead, adds a Nitro plugin to parse and add values from the runtime environment. This will let us update the hash without rebuilding purple and also let us _not_ include that in production, for what that's worth. It accepts multiple values, separated by a comma, just for fun.

Also removes the `'self'` and `https:` script-src directives, which were only present for legacy browser support. Nearly all modern browsers ignore these when `'strict-dynamic'` is present.