### PR TITLE
fix: useAsyncData reactivity

### DIFF
--- a/client/pages/docs/[id]/enqueue.vue
+++ b/client/pages/docs/[id]/enqueue.vue
@@ -80,7 +80,7 @@ const relatedDocuments = [
 ]
 
 const { data: rfcToBe } = await useAsyncData<RfcToBe>(
-  'rfcToBe',
+  computed(() => `rfcToBe-${route.params.id}`),
   () => api.documentsRetrieve({ draftName: route.params.id.toString() }),
   { server: false }
 )

--- a/client/pages/docs/[id]/index.vue
+++ b/client/pages/docs/[id]/index.vue
@@ -168,6 +168,7 @@ const draft = computed(() => {
 const { data: labels } = await useAsyncData(() => api.labelsList(), { server: false, default: () => [] })
 
 const { data: rawDraft, pending: draftPending, refresh: draftRefresh } = await useAsyncData(
+  computed(() => `draft-${route.params.id}`),
   () => api.documentsRetrieve({ draftName: route.params.id.toString() }),
   { server: false }
 )

--- a/client/pages/docs/import.vue
+++ b/client/pages/docs/import.vue
@@ -254,7 +254,7 @@ const { data: labels } = await useAsyncData(
 )
 
 const { data: fetchedData, pending: backendPending } = await useAsyncData(
-  'backendFetch',
+  computed(() => `backendFetch-${route.query.documentId}`),
   async () => {
     try {
       const documentId = Number(route.query.documentId)

--- a/client/pages/docs/index.vue
+++ b/client/pages/docs/index.vue
@@ -51,7 +51,7 @@ const columns: Column[] = [
 ]
 
 const { data: myAssignments, status: assignmentStatus } = await useAsyncData(
-  'myAssignments',
+  computed(() => `myAssignments-${userStore.rpcPersonId}`),
   async () => {
     if (userStore.rpcPersonId === null) {
       return []

--- a/client/pages/queue/[section].vue
+++ b/client/pages/queue/[section].vue
@@ -252,7 +252,9 @@ const columns = computed(() => {
 })
 
 const currentTab = computed(() => {
-  return route.params.section.toString() || 'submissions'
+  const tab = route.params.section.toString() || 'submissions'
+  console.log(`setting currentTab = ${tab}`)
+  return tab
 })
 
 const filteredDocuments = computed(() => {
@@ -302,8 +304,9 @@ const filteredDocuments = computed(() => {
 // INIT
 
 const { data: documents, pending, refresh } = await useAsyncData(
-  () => `queue-${currentTab.value}`, // triggers reload on currentTab.value change
+  computed(() => `queue-${currentTab.value}`),
   async () => {
+    console.log(`currentTab.value = ${currentTab.value}`)
     try {
       if (currentTab.value === 'submissions') {
         return await api.submissionsList()

--- a/client/pages/queue/[section].vue
+++ b/client/pages/queue/[section].vue
@@ -302,7 +302,7 @@ const filteredDocuments = computed(() => {
 // INIT
 
 const { data: documents, pending, refresh } = await useAsyncData(
-  'queue',
+  () => `queue-${currentTab.value}`, // triggers reload on currentTab.value change
   async () => {
     try {
       if (currentTab.value === 'submissions') {


### PR DESCRIPTION
This fixes (at least in dev) the known issue with queue tab switching. It also preemptively applies the same principle to other places where we have parameter-driven requests in a `useAsyncData` call.

As discussed on slack, I tried using `watch` as an alternative to interpolating the parameters into the `key` for `useAsyncData`, but this was not working. When switching queue tabs, changes to the `currentTab.value` were not reflected when the function was called again.