### PR TITLE
feat: Frontend comments

### DIFF
--- a/client/components/RpcTextarea.vue
+++ b/client/components/RpcTextarea.vue
@@ -1,88 +1,52 @@
 <!-- based on https://tailwindui.com/components/application-ui/forms/textareas#component-784309f82e9913989c2196a2d47eff4a -->
-<!-- todo refactor this into a better form -->
 <template>
   <div class="flex items-start space-x-4">
     <div class="flex-shrink-0">
-      <img class="inline-block h-10 w-10 rounded-full"
-           src="https://images.unsplash.com/photo-1550525811-e5869dd03032?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
-           alt=""/>
+      <img
+        class="inline-block h-10 w-10 rounded-full"
+        src="https://images.unsplash.com/photo-1550525811-e5869dd03032?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+        alt=""
+      />
     </div>
     <div class="min-w-0 flex-1">
-      <form action="#" class="relative">
+      <form action="#" class="relative" @submit.prevent="handleSubmit">
         <div
-          class="overflow-hidden rounded-lg shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600">
+          class="overflow-hidden rounded-lg shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600"
+        >
           <label for="comment" class="sr-only">Add your comment</label>
-          <textarea rows="3" name="comment" id="comment"
-                    class="block w-full resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
-                    placeholder="Add your comment..."/>
-
+          <textarea
+            v-model="commentValue"
+            rows="3"
+            name="comment"
+            id="comment"
+            class="block w-full resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
+            placeholder="Add your comment..."
+          />
           <!-- Spacer element to match the height of the toolbar -->
           <div class="py-2" aria-hidden="true">
             <!-- Matches height of button in toolbar (1px border + 36px content height) -->
             <div class="py-px">
-              <div class="h-9"/>
+              <div class="h-9" />
             </div>
           </div>
         </div>
 
-        <div class="absolute inset-x-0 bottom-0 flex justify-between py-2 pl-3 pr-2">
-          <div class="flex items-center space-x-5">
-            <div class="flex items-center">
-              <button type="button"
-                      class="-m-2.5 flex h-10 w-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500">
-                <Icon name="heroicons:paper-clip" class="h-5 w-5" aria-hidden="true"/>
-                <span class="sr-only">Attach a file</span>
-              </button>
-            </div>
-            <div class="flex items-center">
-              <HeadlessListbox as="div" v-model="selected">
-                <HeadlessListboxLabel class="sr-only">Your mood</HeadlessListboxLabel>
-                <div class="relative">
-                  <HeadlessListboxButton
-                    class="relative -m-2.5 flex h-10 w-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500">
-                    <span class="flex items-center justify-center">
-                      <span v-if="selected.value === null">
-                        <Icon name="heroicons:face-smile" class="h-5 w-5 flex-shrink-0" aria-hidden="true"/>
-                        <span class="sr-only">Add your mood</span>
-                      </span>
-                      <span v-if="!(selected.value === null)">
-                        <span :class="[selected.bgColor, 'flex h-8 w-8 items-center justify-center rounded-full']">
-                          <Icon :name="selected.icon" class="h-5 w-5 flex-shrink-0 text-white" aria-hidden="true"/>
-                        </span>
-                        <span class="sr-only">{{ selected.name }}</span>
-                      </span>
-                    </span>
-                  </HeadlessListboxButton>
-
-                  <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100"
-                              leave-to-class="opacity-0">
-                    <HeadlessListboxOptions
-                      class="absolute z-10 -ml-6 mt-1 w-60 rounded-lg bg-white py-3 text-base shadow ring-1 ring-black ring-opacity-5 focus:outline-none sm:ml-auto sm:w-64 sm:text-sm">
-                      <HeadlessListboxOption as="template" v-for="mood in moods" :key="mood.value" :value="mood"
-                                     v-slot="{ active }">
-                        <li
-                          :class="[active ? 'bg-gray-100' : 'bg-white', 'relative cursor-default select-none px-3 py-2']">
-                          <div class="flex items-center">
-                            <div :class="[mood.bgColor, 'flex h-8 w-8 items-center justify-center rounded-full']">
-                              <Icon :name="mood.icon" :class="[mood.iconColor, 'h-5 w-5 flex-shrink-0']"
-                                         aria-hidden="true"/>
-                            </div>
-                            <span class="ml-3 block truncate font-medium">{{ mood.name }}</span>
-                          </div>
-                        </li>
-                      </HeadlessListboxOption>
-                    </HeadlessListboxOptions>
-                  </transition>
-                </div>
-              </HeadlessListbox>
-            </div>
-          </div>
-          <div class="flex-shrink-0">
-            <button type="submit"
-                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-              Post
-            </button>
-          </div>
+        <div
+          class="absolute inset-x-0 bottom-0 flex justify-end py-2 pl-3 pr-2"
+        >
+          <button
+            type="submit"
+            class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            :disabled="isSubmitting"
+          >
+            <Icon
+              v-if="isSubmitting"
+              name="ei:spinner-3"
+              size="1.1em"
+              class="animate-spin mr-1"
+            />
+            Post
+          </button>
         </div>
       </form>
     </div>
@@ -90,16 +54,60 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
+import { localStorageWrapper } from '~/utilities/localstorage'
 
-const moods = [
-  { name: 'Excited', value: 'excited', icon: 'heroicons:fire-20-solid', iconColor: 'text-white', bgColor: 'bg-red-500' },
-  { name: 'Loved', value: 'loved', icon: 'heroicons:heart-20-solid', iconColor: 'text-white', bgColor: 'bg-pink-400' },
-  { name: 'Happy', value: 'happy', icon: 'heroicons:face-smile', iconColor: 'text-white', bgColor: 'bg-green-400' },
-  { name: 'Sad', value: 'sad', icon: 'heroicons:face-frown', iconColor: 'text-white', bgColor: 'bg-yellow-400' },
-  { name: 'Thumbsy', value: 'thumbsy', icon: 'heroicons:hand-thumb-up', iconColor: 'text-white', bgColor: 'bg-blue-500' },
-  { name: 'I feel nothing', value: null, icon: 'heroicons:x-mark', iconColor: 'text-gray-400', bgColor: 'bg-transparent' },
-]
+type Props = {
+  id: number
+  reloadComments: () => void
+}
 
-const selected = ref(moods[5])
+const props = defineProps<Props>()
+
+const api = useApi()
+
+const commentValue = ref('')
+
+const localStorageKey = computed(() => `rpc:saved-comment-${props.id}`)
+
+onMounted(() => {
+  const val = localStorageWrapper.getItem(localStorageKey.value)
+  if (typeof val === 'string') {
+    commentValue.value = `${
+      commentValue.value // preserve any value typed before restoring value
+    }${val}`
+  }
+})
+
+watch(commentValue, () => {
+  localStorageWrapper.setItem(localStorageKey.value, commentValue.value)
+})
+
+const isSubmitting = ref(false)
+
+const snackbar = useSnackbar()
+
+const handleSubmit = async () => {
+  try {
+    isSubmitting.value = true
+    // TODO: verify usage after this is merged https://github.com/ietf-tools/purple/pull/337
+    await api.documentsCommentsCreate({
+      comment: commentValue.value
+    })
+    // assume comment was successfully created so clean up local state
+    isSubmitting.value = false
+    clearLocalStorage()
+    commentValue.value = ''
+  } catch (e: unknown) {
+    isSubmitting.value = false
+    snackbar.add({
+      type: 'error',
+      title: 'Add comment failed. Try again later.',
+      text: String(e)
+    })
+  }
+}
+
+const clearLocalStorage = () =>
+  localStorageWrapper.removeItem(localStorageKey.value)
 </script>

--- a/client/pages/queue/[section].vue
+++ b/client/pages/queue/[section].vue
@@ -54,8 +54,9 @@ import { groupBy } from 'lodash-es'
 import { useSiteStore } from '@/stores/site'
 import Badge from '../../components/BaseBadge.vue'
 import type { Column, Row } from '~/components/DocumentTableTypes'
-import type { Assignment } from '~/purple_client'
+import type { Assignment, QueueItem, SubmissionListItem } from '~/purple_client'
 import type { Tab } from '~/components/TabNavTypes'
+import { assert } from '~/utilities/typescript'
 
 // ROUTING
 
@@ -258,24 +259,28 @@ const currentTab = computed(() => {
 })
 
 const filteredDocuments = computed(() => {
+  if(!documents.value) return []
+
   let docs = []
 
   // -> Filter based on selected tab
   switch (currentTab.value) {
     case 'submissions':
+      console.log('submissions', documents.value)
+
       docs = documents.value
       break
     case 'enqueuing':
-      docs = documents.value?.filter((d: any) => d.disposition === 'created')
+      docs = documents.value.filter((d: any) => d.disposition === 'created')
       break
     case 'pending':
-      docs = documents.value?.filter((d: any) => (d.disposition === 'in_progress') && (d.assignmentSet?.length === 0))
+      docs = documents.value.filter((d: any) => (d.disposition === 'in_progress') && (d.assignmentSet?.length === 0))
       break
     case 'exceptions':
-      docs = documents.value?.filter((d: any) => (d.disposition === 'in_progress') && (d.labels?.filter((lbl: any) => lbl.isException).length))
+      docs = documents.value.filter((d: any) => (d.disposition === 'in_progress') && (d.labels?.filter((lbl: any) => lbl.isException).length))
       break
     case 'inprocess':
-      docs = documents.value?.filter((d: any) => (d.disposition === 'in_progress') && (d.assignmentSet?.length > 0)).map((d: any) => ({
+      docs = documents.value.filter((d: any) => (d.disposition === 'in_progress') && (d.assignmentSet?.length > 0)).map((d: any) => ({
         ...d,
         currentState: `${d.assignmentSet[0].role} (${d.assignmentSet[0].state})`,
         assignee: d.assignmentSet[0],
@@ -317,7 +322,7 @@ const { data: documents, pending, refresh } = await useAsyncData(
       snackbar.add({
         type: 'error',
         title: 'Fetch Failed',
-        text: err
+        text: String(err)
       })
     }
   },


### PR DESCRIPTION
## feat

Allows posting of comments, and (re)loads comments using the API. Doesn't allow edits to comments yet even though the API supports it.

The user's comment is persisted in `localStorage` until they submit it when localStorage is cleared. This is so that they can browse away and come back to continue writing a comment. If the user's device was compromised these draft comments could be copied, but I presume we trust the device's security so this doesn't matter.

Depends on #337

Once that's merged I'll get this PR into shape.