### PR TITLE
fix: create DatatrackerPerson as needed for User

### DIFF
--- a/rpcauth/models.py
+++ b/rpcauth/models.py
@@ -25,6 +25,11 @@ class User(AbstractUser):
     avatar = models.URLField(blank=True)
 
     def datatracker_person(self):
-        return DatatrackerPerson.objects.by_subject_id(
-            self.datatracker_subject_id
-        ).first()
+        try:
+            dt_person, _ = DatatrackerPerson.objects.get_or_create_by_subject_id(
+                self.datatracker_subject_id
+            )
+        except DatatrackerPerson.DoesNotExist:
+            dt_person = None
+        return dt_person
+


### PR DESCRIPTION
Replace `by_subject_id()` with `get_or_create_by_subject_id()`. We can reintroduce the former if we need it, but we only used it for finding the `DatatrackerPerson` corresponding to a `User`. With this change, the `DatatrackerPerson` is created for a `User` when first needed.

N.b., the `typing.cast()` method informs the type checker that we know `get_or_create()` will return the correct model type, but does not impact runtime at all.