### PR TITLE
feat: object-level permissions for comments

### DIFF
--- a/purple/settings/base.py
+++ b/purple/settings/base.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "drf_spectacular",
     "rest_framework",
+    "rules.apps.AutodiscoverRulesConfig",
     "simple_history",
     "datatracker.apps.DatatrackerConfig",
     "rpc.apps.RpcConfig",
@@ -68,6 +69,7 @@ WSGI_APPLICATION = "purple.wsgi.application"
 # Authentication
 AUTHENTICATION_BACKENDS = (
     "rpcauth.backends.RpcOIDCAuthBackend",
+    "rules.permissions.ObjectPermissionBackend",
     "django.contrib.auth.backends.ModelBackend",  # default backend
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django>=5.0
 django-filter>=25.1
+rules>=3.5
 django-simple-history>=3.4
 djangorestframework>=3.14
 drf-spectacular>=0.27

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -24,10 +24,10 @@ from drf_spectacular.utils import (
     extend_schema_view,
     OpenApiParameter,
 )
-
 import rpcapi_client
-from datatracker.rpcapi import with_rpcapi
+from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
+from datatracker.rpcapi import with_rpcapi
 from datatracker.models import Document
 from .models import (
     Assignment,
@@ -423,6 +423,7 @@ class TlpBoilerplateChoiceNameViewSet(viewsets.ReadOnlyModelViewSet):
     ),
 )
 class DocumentCommentViewSet(
+    AutoPermissionViewSetMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     mixins.UpdateModelMixin,

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -7,16 +7,19 @@ from dataclasses import dataclass
 from itertools import pairwise
 from typing import Optional
 
+import rules
 from django.db import models
 from django.utils import timezone
+from rules.contrib.models import RulesModel
+from simple_history.models import HistoricalRecords
 
-from rpc.dt_v1_api_utils import (
+from .dt_v1_api_utils import (
     DatatrackerFetchFailure,
     NoSuchSlug,
     datatracker_stdlevelname,
     datatracker_streamname,
 )
-from simple_history.models import HistoricalRecords
+from .rules import is_comment_author, is_rpc_person
 
 
 class DumpInfo(models.Model):
@@ -511,7 +514,7 @@ class RpcRelatedDocument(models.Model):
         return f"{self.relationship} relationship from {self.source} to {target}"
 
 
-class RpcDocumentComment(models.Model):
+class RpcDocumentComment(RulesModel):
     """Private RPC comment about a draft, RFC or RFC-to-be"""
 
     document = models.ForeignKey(
@@ -535,6 +538,12 @@ class RpcDocumentComment(models.Model):
                 violation_error_message="exactly one of document or rfc_to_be must be set",
             )
         ]
+        # Permissions applied via AutoPermissionViewSetMixin
+        rules_permissions = {
+            "add": is_rpc_person,
+            "change": is_comment_author,
+            "delete": rules.always_deny,
+        }
 
     def __str__(self):
         target = self.document if self.document else self.rfc_to_be

--- a/rpc/rules.py
+++ b/rpc/rules.py
@@ -1,0 +1,12 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+import rules
+
+
+@rules.predicate
+def is_rpc_person(user):
+    return hasattr(user.datatracker_person(), "rpcperson")
+
+
+@rules.predicate
+def is_comment_author(user, comment):
+    return comment.by_id == user.datatracker_person().pk


### PR DESCRIPTION
Adds the [rules](https://github.com/dfunckt/django-rules) package for object-level permissions management. Applies to `RpcDocumentComment` as a first demonstration.