### PR TITLE
feat: add endpoints to list/retrieve/update/destroy RfcAuthors

### DIFF
--- a/purple/urls.py
+++ b/purple/urls.py
@@ -57,6 +57,11 @@ router.register(
     rpc_api.DocumentCommentViewSet,
     basename="documents-comments",
 )
+router.register(
+    r"documents/(?P<draft_name>[^/.]+)/authors",
+    rpc_api.RpcAuthorViewSet,
+    basename="documents-authors",
+)
 router.register(r"labels", rpc_api.LabelViewSet)
 router.register(r"queue", rpc_api.QueueViewSet, basename="queue")
 router.register(r"rpc_person", rpc_api.RpcPersonViewSet)

--- a/rpc/admin.py
+++ b/rpc/admin.py
@@ -78,7 +78,12 @@ admin.site.register(Assignment, AssignmentAdmin)
 
 
 class RfcAuthorAdmin(admin.ModelAdmin):
-    search_fields = ["datatracker_person__datatracker_id"]
+    search_fields = [
+        "datatracker_person__datatracker_id",
+        "titlepage_name",
+        "rfc_to_be__rfc_number",
+    ]
+    list_display = ["titlepage_name", "rfc_to_be", "is_editor"]
 
 
 class ApprovalLogMessageAdmin(admin.ModelAdmin):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -35,6 +35,7 @@ from .models import (
     Cluster,
     Label,
     RfcToBe,
+    RfcAuthor,
     RpcPerson,
     RpcRole,
     SourceFormatName,
@@ -65,6 +66,8 @@ from .serializers import (
     VersionInfoSerializer,
     check_user_has_role,
     DocumentCommentSerializer,
+    RfcAuthorSerializer,
+    CreateRfcAuthorSerializer,
 )
 from .utils import VersionInfo
 
@@ -336,6 +339,23 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
         in_progress = RfcToBe.objects.filter(disposition_id="in_progress")
         serializer = self.get_serializer(in_progress, many=True)
         return Response(serializer.data)
+
+
+class RpcAuthorViewSet(viewsets.ModelViewSet):
+    def get_queryset(self):
+        return RfcAuthor.objects.filter(
+            rfc_to_be__draft__name=self.kwargs["draft_name"]
+        )
+
+    def perform_create(self, serializer):
+        rfc_to_be = RfcToBe.objects.get(draft__name=self.kwargs["draft_name"])
+        serializer.save(rfc_to_be=rfc_to_be)
+
+    def get_serializer_class(self):
+        """Use different serializer for create vs other operations"""
+        if self.action == "create":
+            return CreateRfcAuthorSerializer
+        return RfcAuthorSerializer
 
 
 class LabelViewSet(viewsets.ModelViewSet):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -348,7 +348,11 @@ class RpcAuthorViewSet(viewsets.ModelViewSet):
         )
 
     def perform_create(self, serializer):
-        rfc_to_be = RfcToBe.objects.get(draft__name=self.kwargs["draft_name"])
+        rfc_to_be = RfcToBe.objects.filter(
+            draft__name=self.kwargs["draft_name"]
+        ).first()
+        if rfc_to_be is None:
+            raise NotFound("RfcToBe with the given draft name does not exist")
         serializer.save(rfc_to_be=rfc_to_be)
 
     def get_serializer_class(self):

--- a/rpc/migrations/0014_rfcauthor_unique_author_per_document.py
+++ b/rpc/migrations/0014_rfcauthor_unique_author_per_document.py
@@ -1,0 +1,21 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("datatracker", "0002_initial"),
+        ("rpc", "0013_alter_actionholder_body"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="rfcauthor",
+            constraint=models.UniqueConstraint(
+                fields=("datatracker_person", "rfc_to_be"),
+                name="unique_author_per_document",
+                violation_error_message="the person is already an author of this document",
+            ),
+        ),
+    ]

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -328,6 +328,15 @@ class RfcAuthor(models.Model):
     def __str__(self):
         return f"{self.datatracker_person} as author of {self.rfc_to_be}"
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["datatracker_person", "rfc_to_be"],
+                name="unique_author_per_document",
+                violation_error_message="the person is already an author of this document",
+            )
+        ]
+
 
 class AdditionalEmail(models.Model):
     email = models.EmailField()

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -164,6 +164,11 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "datatracker_person"]
 
 
+class CreateRfcAuthorSerializer(RfcAuthorSerializer):
+    class Meta(RfcAuthorSerializer.Meta):
+        read_only_fields = ["id"]
+
+
 class RfcToBeSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField()
     rev = serializers.SerializerMethodField()


### PR DESCRIPTION
1) added endpoints:

List all authors of doc:
GET /documents/<draft_name>/authors/

Create author:
POST /documents/<draft_name>/authors/

Retrieve author:
GET /documents/<draft_name>/authors/<author_id>/

Update author:
PUT /documents/<draft_name>/authors/<author_id>/

Partial update author:
PATCH /documents/<draft_name>/authors/<author_id>/

Delete author:
DELETE /documents/<draft_name>/authors/<author_id>/

2) added constraint for unique DT-Person per Doc in RfcAuthor