### PR TITLE
fix: blank=True for several RpcPerson fields

### DIFF
--- a/rpc/migrations/0015_alter_rpcperson_can_hold_role_and_more.py
+++ b/rpc/migrations/0015_alter_rpcperson_can_hold_role_and_more.py
@@ -1,0 +1,35 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rpc", "0014_rfcauthor_unique_author_per_document"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="rpcperson",
+            name="can_hold_role",
+            field=models.ManyToManyField(blank=True, to="rpc.rpcrole"),
+        ),
+        migrations.AlterField(
+            model_name="rpcperson",
+            name="capable_of",
+            field=models.ManyToManyField(blank=True, to="rpc.capability"),
+        ),
+        migrations.AlterField(
+            model_name="rpcperson",
+            name="manager",
+            field=models.ForeignKey(
+                blank=True,
+                limit_choices_to={"can_hold_role__slug": "manager"},
+                null=True,
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="managed_people",
+                to="rpc.rpcperson",
+            ),
+        ),
+    ]

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -30,11 +30,12 @@ class RpcPerson(models.Model):
     datatracker_person = models.OneToOneField(
         "datatracker.DatatrackerPerson", on_delete=models.PROTECT
     )
-    can_hold_role = models.ManyToManyField("RpcRole")
-    capable_of = models.ManyToManyField("Capability")
+    can_hold_role = models.ManyToManyField("RpcRole", blank=True)
+    capable_of = models.ManyToManyField("Capability", blank=True)
     hours_per_week = models.PositiveSmallIntegerField(default=40)
     manager = models.ForeignKey(
         "RpcPerson",
+        blank=True,
         null=True,
         on_delete=models.RESTRICT,
         limit_choices_to={"can_hold_role__slug": "manager"},


### PR DESCRIPTION
Allows RpcPerson to be created/managed in the admin. Does not affect the database schema.