### PR TITLE
chore: deploy statics for k8s staging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,18 @@ jobs:
           push: true
           tags: ghcr.io/ietf-tools/purple-backend:latest
 
+      - name: Build statics image
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: .
+          file: dev/build/statics.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/ietf-tools/purple-statics:latest
+
       - name: Generate Purple API client
         run: |
           container_id="$(docker create ghcr.io/ietf-tools/purple-backend:latest)"

--- a/dev/build/backend.Dockerfile
+++ b/dev/build/backend.Dockerfile
@@ -14,9 +14,8 @@ COPY ./dev/build/gunicorn.conf.py ./gunicorn.conf.py
 
 RUN pip3 --disable-pip-version-check --no-cache-dir install -r requirements.txt
 
-# Generate Purple openapi schema and collect statics
-RUN PURPLE_DEPLOYMENT_MODE=build ./manage.py collectstatic --no-input && \
-    PURPLE_DEPLOYMENT_MODE=build ./manage.py spectacular --file purple_api.yaml --validate # --fail-on-warn (when we can)
+# Generate Purple openapi schema
+RUN PURPLE_DEPLOYMENT_MODE=build ./manage.py spectacular --file purple_api.yaml --validate # --fail-on-warn (when we can)
 
 RUN chmod +x start.sh && \
     chmod +x backend-start.sh && \

--- a/dev/build/statics.Dockerfile
+++ b/dev/build/statics.Dockerfile
@@ -3,9 +3,11 @@ FROM ghcr.io/ietf-tools/purple-backend:latest AS builder
  # Collect statics
 RUN PURPLE_DEPLOYMENT_MODE=build ./manage.py collectstatic --no-input
 
-
-FROM nginx:latest
+FROM ghcr.io/nginxinc/nginx-unprivileged:1.27
 LABEL maintainer="IETF Tools Team <tools-discuss@ietf.org>"
 
+# install the static files
 COPY --from=builder /workspace/purple/static /usr/share/nginx/html/static/
 
+# listen on port 8042 instead of 8080
+RUN sed --in-place 's/8080/8042/' /etc/nginx/conf.d/default.conf

--- a/dev/build/statics.Dockerfile
+++ b/dev/build/statics.Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/ietf-tools/purple-backend:latest AS builder
+
+ # Collect statics
+RUN PURPLE_DEPLOYMENT_MODE=build ./manage.py collectstatic --no-input
+
+
+FROM nginx:latest
+LABEL maintainer="IETF Tools Team <tools-discuss@ietf.org>"
+
+COPY --from=builder /workspace/purple/static /usr/share/nginx/html/static/
+

--- a/k8s/nginx-purple.conf
+++ b/k8s/nginx-purple.conf
@@ -16,7 +16,7 @@ server {
         return 200 "User-agent: *\nDisallow: /\n";
     }
 
-    location ~ ^/(admin|api|login|oidc|static)/ {
+    location ~ ^/(admin|api|login|oidc)/ {
         proxy_set_header Host $${keepempty}host;
         proxy_set_header Connection close;
         proxy_set_header X-Request-Start "t=$${keepempty}msec";
@@ -31,6 +31,19 @@ server {
 
     location = /login {
         rewrite .* /oidc/authenticate/ redirect;
+    }
+
+    location ~ ^/static/ {
+        proxy_set_header Host $${keepempty}host;
+        proxy_set_header Connection close;
+        proxy_set_header X-Request-Start "t=$${keepempty}msec";
+        proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
+        proxy_pass http://localhost:8042;
+        # Set timeouts longer than Cloudflare proxy limits
+        proxy_connect_timeout 60;  # nginx default (Cf = 15)
+        proxy_read_timeout 120;  # nginx default = 60 (Cf = 100)
+        proxy_send_timeout 60;  # nginx default = 60 (Cf = 30)
+        client_max_body_size 0;  # disable size check
     }
 
     location / {

--- a/k8s/purple.yaml
+++ b/k8s/purple.yaml
@@ -95,13 +95,9 @@ spec:
         - name: statics
           image: "ghcr.io/ietf-tools/purple-statics:$APP_IMAGE_TAG"
           imagePullPolicy: Always
-          ports:
-            - containerPort: 80
-              name: http
-              protocol: TCP
           livenessProbe:
             httpGet:
-              port: 80
+              port: 8042
               path: /
           securityContext:
             readOnlyRootFilesystem: true

--- a/k8s/purple.yaml
+++ b/k8s/purple.yaml
@@ -90,6 +90,22 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
         # -----------------------------------------------------
+        # Statics Container
+        # -----------------------------------------------------
+        - name: statics
+          image: "ghcr.io/ietf-tools/purple-statics:$APP_IMAGE_TAG"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              port: 80
+              path: /
+          securityContext:
+            readOnlyRootFilesystem: true
+        # -----------------------------------------------------
         # Nginx Container
         # -----------------------------------------------------
         - name: nginx


### PR DESCRIPTION
Builds and deploys a statics server so the admin pages will work in staging. (Likely a temporary arrangement until we build out external statics handling/serving.)