### PR TITLE
feat: search_datatrackerpersons API

### DIFF
--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -64,9 +64,7 @@ class DatatrackerPerson(models.Model):
         if cached_value is None:
             return None
         return getattr(
-            rpcapi_client.models.person.Person.from_json(cached_value),
-            field_name,
-            None
+            rpcapi_client.models.person.Person.from_json(cached_value), field_name, None
         )
 
 

--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -50,7 +50,7 @@ class DatatrackerPerson(models.Model):
     @with_rpcapi
     def _fetch(self, field_name, *, rpcapi: rpcapi_client.DefaultApi):
         """Get field_name value for person (uses cache)"""
-        cache_key = f"datatracker_person-{self.datatracker_id}-{field_name}"
+        cache_key = f"datatracker_person-{self.datatracker_id}"
         no_value = object()
         cached_value = cache.get(cache_key, no_value)
         if cached_value is no_value:
@@ -59,9 +59,15 @@ class DatatrackerPerson(models.Model):
             except rpcapi_client.exceptions.NotFoundException:
                 cached_value = None
             else:
-                cached_value = getattr(person, field_name)
+                cached_value = person.to_json()
             cache.set(cache_key, cached_value)
-        return cached_value
+        if cached_value is None:
+            return None
+        return getattr(
+            rpcapi_client.models.person.Person.from_json(cached_value),
+            field_name,
+            None
+        )
 
 
 class Document(models.Model):

--- a/purple/urls.py
+++ b/purple/urls.py
@@ -88,6 +88,9 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("oidc/", include("mozilla_django_oidc.urls")),
     path("login/", views.index),
+    path(
+        "api/rpc/search/datatrackerpersons/", rpc_api.DatatrackerPersonSearch.as_view()
+    ),
     path("api/rpc/profile/", rpc_api.profile),
     path(
         "api/rpc/profile/<int:rpc_person_id>", rpc_api.profile_as_person

--- a/purple/urls.py
+++ b/purple/urls.py
@@ -89,7 +89,7 @@ urlpatterns = [
     path("oidc/", include("mozilla_django_oidc.urls")),
     path("login/", views.index),
     path(
-        "api/rpc/search/datatrackerpersons/", rpc_api.DatatrackerPersonSearch.as_view()
+        "api/rpc/search/datatrackerpersons/", rpc_api.SearchDatatrackerPersons.as_view()
     ),
     path("api/rpc/profile/", rpc_api.profile),
     path(

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -663,6 +663,7 @@ class SearchDatatrackerPersonsPagination(LimitOffsetPagination):
 @dataclass
 class DatatrackerPersonModelShim:
     """Stand-in for a DatatrackerPerson using results from the rpc_person_search_list() API"""
+
     datatracker_id: int
     plain_name: str
     picture: str
@@ -682,6 +683,7 @@ class SearchDatatrackerPersons(ListAPIView):
 
     Search for a datatracker person by name/email fragment.
     """
+
     # Warning: this is a tricky view!
     #
     # Rather than querying the database, the `get_queryset()` method makes a datatracker API call
@@ -708,7 +710,10 @@ class SearchDatatrackerPersons(ListAPIView):
             offset=offset,
         )
         return PaginationPassthroughWrapper(
-            data=[DatatrackerPersonModelShim.from_rpcapi_rpcperson(r) for r in upstream_results.results],
+            data=[
+                DatatrackerPersonModelShim.from_rpcapi_rpcperson(r)
+                for r in upstream_results.results
+            ],
             total_count=upstream_results.count,
             offset=offset,
         )

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -72,7 +72,7 @@ from .serializers import (
     DocumentCommentSerializer,
     RfcAuthorSerializer,
     CreateRfcAuthorSerializer,
-    DatatrackerPersonSerializer,
+    BaseDatatrackerPersonSerializer,
 )
 from .utils import VersionInfo, create_rpc_related_document
 
@@ -640,7 +640,7 @@ class SearchDatatrackerPersonsPagination(LimitOffsetPagination):
 
 @extend_schema_view(get=extend_schema(operation_id="search_datatrackerpersons"))
 class SearchDatatrackerPersons(ListAPIView):
-    serializer_class = DatatrackerPersonSerializer
+    serializer_class = BaseDatatrackerPersonSerializer
     pagination_class = SearchDatatrackerPersonsPagination
 
     def get_queryset(self):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -644,6 +644,9 @@ class SearchDatatrackerPersons(ListAPIView):
     pagination_class = SearchDatatrackerPersonsPagination
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            # Be sure we don't make an API call during schema generation
+            return DatatrackerPerson.objects.none()
         offset = self.paginator.get_offset(self.request)
         upstream_results = self.upstream_search(
             search=self.request.GET.get("search", ""),

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -633,10 +633,15 @@ class PassthroughWrapper:
         return self._data.results[adjusted_item]
 
 
+class SearchDatatrackerPersonsPagination(LimitOffsetPagination):
+    default_limit = 10
+    max_limit = 100
+
+
 @extend_schema_view(get=extend_schema(operation_id="search_datatrackerpersons"))
 class SearchDatatrackerPersons(ListAPIView):
     serializer_class = DatatrackerPersonSerializer
-    pagination_class = DefaultLimitOffsetPagination
+    pagination_class = SearchDatatrackerPersonsPagination
 
     def get_queryset(self):
         offset = self.paginator.get_offset(self.request)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -11,7 +11,7 @@ from rest_framework.decorators import (
     action,
     api_view,
 )
-from rest_framework.generics import GenericAPIView, ListAPIView
+from rest_framework.generics import ListAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 from rest_framework.exceptions import (
@@ -633,15 +633,10 @@ class PassthroughWrapper:
         return self._data.results[adjusted_item]
 
 
-class PassthroughLimitOffsetPagination(LimitOffsetPagination):
-    default_limit = 10
-    max_limit = 100
-
-
 @extend_schema_view(get=extend_schema(operation_id="search_datatrackerpersons"))
-class DatatrackerPersonSearch(ListAPIView):
+class SearchDatatrackerPersons(ListAPIView):
     serializer_class = DatatrackerPersonSerializer
-    pagination_class = PassthroughLimitOffsetPagination
+    pagination_class = DefaultLimitOffsetPagination
 
     def get_queryset(self):
         offset = self.paginator.get_offset(self.request)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -622,6 +622,7 @@ class PaginationPassthroughWrapper:
     to the .results list, adjusting the indexes to compensate for the offset that was
     already applied.
     """
+
     def __init__(self, paginated_result, offset):
         self._data = paginated_result
         self._offset = offset
@@ -635,7 +636,9 @@ class PaginationPassthroughWrapper:
         # so we don't need to implement esoteric corner cases. Offset and limit are always non-negative.
         if isinstance(item, slice):
             # A slice represents `results[start:stop:step]` - subtract offset from start and stop
-            if (item.start is not None and item.start < 0) or (item.stop is not None and item.stop < 0):
+            if (item.start is not None and item.start < 0) or (
+                item.stop is not None and item.stop < 0
+            ):
                 raise NotImplementedError("Negative indexing not supported")
             adjusted_item = slice(
                 None if item.start is None else item.start - self._offset,
@@ -677,6 +680,7 @@ class SearchDatatrackerPersons(ListAPIView):
     API results from datatracker, this creates un-saved `DatatrackerPerson` instances with a
     datatracker_id corresponding to each API result's ID.
     """
+
     serializer_class = BaseDatatrackerPersonSerializer
     pagination_class = SearchDatatrackerPersonsPagination
 
@@ -694,9 +698,13 @@ class SearchDatatrackerPersons(ListAPIView):
 
     def get_serializer(self, *args, **kwargs):
         if len(args) > 0:
-            args = ([DatatrackerPerson(datatracker_id=record.id) for record in args[0]],) + args[1:]
+            args = (
+                [DatatrackerPerson(datatracker_id=record.id) for record in args[0]],
+            ) + args[1:]
         return super().get_serializer(*args, **kwargs)
 
     @with_rpcapi
-    def upstream_search(self, search, limit, offset, *, rpcapi: rpcapi_client.DefaultApi):
+    def upstream_search(
+        self, search, limit, offset, *, rpcapi: rpcapi_client.DefaultApi
+    ):
         return rpcapi.rpc_person_search_list(search=search, limit=limit, offset=offset)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -662,14 +662,14 @@ class SearchDatatrackerPersonsPagination(LimitOffsetPagination):
 
 @dataclass
 class DatatrackerPersonModelShim:
-    """Stand-in for a DatatrackerPerson using results from the rpc_person_search_list() API"""
+    """Stand-in for a DatatrackerPerson using results from the search_person() API"""
 
     datatracker_id: int
     plain_name: str
     picture: str
 
     @classmethod
-    def from_rpcapi_rpcperson(cls, obj: rpcapi_client.models.rpc_person.RpcPerson):
+    def from_rpcapi_person(cls, obj: rpcapi_client.models.person.Person):
         return cls(
             datatracker_id=obj.id,
             plain_name=obj.plain_name,
@@ -711,7 +711,7 @@ class SearchDatatrackerPersons(ListAPIView):
         )
         return PaginationPassthroughWrapper(
             data=[
-                DatatrackerPersonModelShim.from_rpcapi_rpcperson(r)
+                DatatrackerPersonModelShim.from_rpcapi_person(r)
                 for r in upstream_results.results
             ],
             total_count=upstream_results.count,
@@ -722,4 +722,4 @@ class SearchDatatrackerPersons(ListAPIView):
     def upstream_search(
         self, search, limit, offset, *, rpcapi: rpcapi_client.DefaultApi
     ):
-        return rpcapi.rpc_person_search_list(search=search, limit=limit, offset=offset)
+        return rpcapi.search_person(search=search, limit=limit, offset=offset)

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -46,13 +46,13 @@ class VersionInfoSerializer(serializers.Serializer):
 class DatatrackerPersonSerializer(serializers.ModelSerializer):
     """Serialize a DatatrackerPerson"""
 
-    person_id = serializers.IntegerField(source="id")
+    person_id = serializers.IntegerField(source="datatracker_id")
     name = serializers.CharField(source="plain_name", read_only=True)
 
     class Meta:
         model = DatatrackerPerson
         fields = ["person_id", "name", "rpcperson", "picture"]
-        read_only_fields = ["rpcperson"]
+        read_only_fields = ["rpcperson", "picture"]
 
 
 @dataclass

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from django.conf import settings
 from itertools import pairwise
 
-from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from rest_framework.fields import empty
 from simple_history.models import ModelDelta
@@ -63,7 +62,9 @@ class DatatrackerPersonSerializer(BaseDatatrackerPersonSerializer):
 
     class Meta(BaseDatatrackerPersonSerializer.Meta):
         fields = BaseDatatrackerPersonSerializer.Meta.fields + ["rpcperson"]
-        read_only_fields = BaseDatatrackerPersonSerializer.Meta.read_only_fields + ["rpcperson"]
+        read_only_fields = BaseDatatrackerPersonSerializer.Meta.read_only_fields + [
+            "rpcperson"
+        ]
 
 
 @dataclass

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -43,16 +43,27 @@ class VersionInfoSerializer(serializers.Serializer):
     dump_timestamp = serializers.DateTimeField(required=False, read_only=True)
 
 
-class DatatrackerPersonSerializer(serializers.ModelSerializer):
-    """Serialize a DatatrackerPerson"""
+class BaseDatatrackerPersonSerializer(serializers.ModelSerializer):
+    """Serialize a minimal DatatrackerPerson
+
+    This is the serializer to use if you may be working with non-persisted DatatrackerPerson instances.
+    """
 
     person_id = serializers.IntegerField(source="datatracker_id")
     name = serializers.CharField(source="plain_name", read_only=True)
 
     class Meta:
         model = DatatrackerPerson
-        fields = ["person_id", "name", "rpcperson", "picture"]
-        read_only_fields = ["rpcperson", "picture"]
+        fields = ["person_id", "name", "picture"]
+        read_only_fields = ["picture"]
+
+
+class DatatrackerPersonSerializer(BaseDatatrackerPersonSerializer):
+    """Serializer a DatatrackerPerson, including all the bells and whistles"""
+
+    class Meta(BaseDatatrackerPersonSerializer.Meta):
+        fields = BaseDatatrackerPersonSerializer.Meta.fields + ["rpcperson"]
+        read_only_fields = BaseDatatrackerPersonSerializer.Meta.read_only_fields + ["rpcperson"]
 
 
 @dataclass


### PR DESCRIPTION
Adds a `search_datatrackerpersons` API call. This makes an upstream call to a new datatracker rpcapi endpoint that performs a `Person` search.

There's some complexity around making this work with DRF's gearing, particularly for pagination and schema generation. If this has crossed the threshold into "too much magic" it would be possible to consider a more explicit implementation, but there'll be a fair bit of repetitive code / explicit schema annotation.