### PR TITLE
feat: add CRUD endpoints for doc-references

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -77,8 +77,6 @@ from .serializers import (
     check_user_has_role,
     DocumentCommentSerializer,
     RfcAuthorSerializer,
-    CreateRfcAuthorSerializer,
-    CreateRpcRelatedDocumentSerializer,
 )
 from .utils import VersionInfo, create_rpc_related_document
 
@@ -443,6 +441,7 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
 @extend_schema_with_draft_name()
 class RpcAuthorViewSet(viewsets.ModelViewSet):
     queryset = RfcAuthor.objects.all()
+    serializer_class = RfcAuthorSerializer
 
     def get_queryset(self):
         return (
@@ -459,27 +458,16 @@ class RpcAuthorViewSet(viewsets.ModelViewSet):
             raise NotFound("RfcToBe with the given draft name does not exist")
         serializer.save(rfc_to_be=rfc_to_be)
 
-    def get_serializer_class(self):
-        """Use different serializer for create vs other operations"""
-        if self.action == "create":
-            return CreateRfcAuthorSerializer
-        return RfcAuthorSerializer
-
 
 @extend_schema_with_draft_name()
 class RpcRelatedDocumentViewSet(viewsets.ModelViewSet):
     queryset = RpcRelatedDocument.objects.all()
+    serializer_class = RpcRelatedDocumentSerializer
 
     def get_queryset(self):
         return (
             super().get_queryset().filter(source__draft__name=self.kwargs["draft_name"])
         )
-
-    def get_serializer_class(self):
-        """Use different serializer for create vs other operations"""
-        if self.action == "create":
-            return CreateRpcRelatedDocumentSerializer
-        return RpcRelatedDocumentSerializer
 
 
 class LabelViewSet(viewsets.ModelViewSet):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -55,7 +55,6 @@ from .serializers import (
     BaseDatatrackerPersonSerializer,
     CapabilitySerializer,
     ClusterSerializer,
-    CreateRfcAuthorSerializer,
     CreateRfcToBeSerializer,
     DocumentCommentSerializer,
     LabelSerializer,
@@ -75,8 +74,6 @@ from .serializers import (
     TlpBoilerplateChoiceNameSerializer,
     VersionInfoSerializer,
     check_user_has_role,
-    DocumentCommentSerializer,
-    RfcAuthorSerializer,
 )
 from .utils import VersionInfo, create_rpc_related_document
 

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -75,16 +75,35 @@ from .serializers import (
     TlpBoilerplateChoiceNameSerializer,
     VersionInfoSerializer,
     check_user_has_role,
+    DocumentCommentSerializer,
+    RfcAuthorSerializer,
+    CreateRfcAuthorSerializer,
+    CreateRpcRelatedDocumentSerializer,
 )
 from .utils import VersionInfo, create_rpc_related_document
 
 
+@extend_schema(operation_id="version", responses=VersionInfoSerializer)
 @api_view(["GET"])
 def version(request):
     """Get application version information"""
     return JsonResponse(VersionInfoSerializer(VersionInfo()).data)
 
 
+@extend_schema(
+    operation_id="profile",
+    responses=inline_serializer(
+        name="Profile",
+        fields={
+            "authenticated": serializers.BooleanField(),
+            "id": serializers.IntegerField(),
+            "name": serializers.CharField(),
+            "avatar": serializers.CharField(),
+            "rpcPersonId": serializers.IntegerField(allow_null=True),
+            "isManager": serializers.BooleanField(),
+        },
+    ),
+)
 @api_view(["GET"])
 def profile(request):
     """Get profile of current user"""
@@ -129,6 +148,26 @@ def profile_as_person(request, rpc_person_id):
                 if rpcperson is None
                 else rpcperson.can_hold_role.filter(slug="manager").exists()
             ),
+        }
+    )
+
+
+def extend_schema_with_draft_name(actions=None):
+    if actions is None:
+        actions = [
+            "list",
+            "retrieve",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+        ]
+    return extend_schema_view(
+        **{
+            action: extend_schema(
+                parameters=[OpenApiParameter("draft_name", OpenApiTypes.STR, "path")]
+            )
+            for action in actions
         }
     )
 
@@ -401,21 +440,7 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-@extend_schema_view(
-    **{
-        action: extend_schema(
-            parameters=[OpenApiParameter("draft_name", OpenApiTypes.STR, "path")]
-        )
-        for action in [
-            "list",
-            "retrieve",
-            "create",
-            "update",
-            "partial_update",
-            "destroy",
-        ]
-    }
-)
+@extend_schema_with_draft_name()
 class RpcAuthorViewSet(viewsets.ModelViewSet):
     queryset = RfcAuthor.objects.all()
 
@@ -441,13 +466,20 @@ class RpcAuthorViewSet(viewsets.ModelViewSet):
         return RfcAuthorSerializer
 
 
-class RpcRelatedDocumentViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = RpcRelatedDocumentSerializer
+@extend_schema_with_draft_name()
+class RpcRelatedDocumentViewSet(viewsets.ModelViewSet):
+    queryset = RpcRelatedDocument.objects.all()
 
     def get_queryset(self):
-        return RpcRelatedDocument.objects.filter(
-            source__draft__name=self.kwargs["draft_name"]
+        return (
+            super().get_queryset().filter(source__draft__name=self.kwargs["draft_name"])
         )
+
+    def get_serializer_class(self):
+        """Use different serializer for create vs other operations"""
+        if self.action == "create":
+            return CreateRpcRelatedDocumentSerializer
+        return RpcRelatedDocumentSerializer
 
 
 class LabelViewSet(viewsets.ModelViewSet):
@@ -520,19 +552,7 @@ class TlpBoilerplateChoiceNameViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = TlpBoilerplateChoiceNameSerializer
 
 
-@extend_schema_view(
-    **{
-        action: extend_schema(
-            parameters=[OpenApiParameter("draft_name", OpenApiTypes.STR, "path")]
-        )
-        for action in [
-            "list",
-            "create",
-            "update",
-            "partial_update",
-        ]
-    }
-)
+@extend_schema_with_draft_name(actions=["list", "create", "update", "partial_update"])
 class DocumentCommentViewSet(
     AutoPermissionViewSetMixin,
     mixins.ListModelMixin,

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -333,7 +333,12 @@ class RpcRelatedDocumentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = RpcRelatedDocument
-        fields = ["relationship", "source", "target_document", "target_rfctobe"]
+        fields = ["id", "relationship", "source", "target_document", "target_rfctobe"]
+
+
+class CreateRpcRelatedDocumentSerializer(RpcRelatedDocumentSerializer):
+    class Meta(RpcRelatedDocumentSerializer.Meta):
+        read_only_fields = ["id"]
 
 
 class CapabilitySerializer(serializers.ModelSerializer):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -181,11 +181,6 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "datatracker_person"]
 
 
-class CreateRfcAuthorSerializer(RfcAuthorSerializer):
-    class Meta(RfcAuthorSerializer.Meta):
-        read_only_fields = ["id"]
-
-
 class RfcToBeSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField()
     rev = serializers.SerializerMethodField()
@@ -334,11 +329,6 @@ class RpcRelatedDocumentSerializer(serializers.ModelSerializer):
     class Meta:
         model = RpcRelatedDocument
         fields = ["id", "relationship", "source", "target_document", "target_rfctobe"]
-
-
-class CreateRpcRelatedDocumentSerializer(RpcRelatedDocumentSerializer):
-    class Meta(RpcRelatedDocumentSerializer.Meta):
-        read_only_fields = ["id"]
 
 
 class CapabilitySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
also:
- add schema-extensions to fix ERRORs for version/profile viewsets
- use reusable function _extend_schema_with_draft_name_ to DRY