### PR TITLE
fix: navigate to enqueuing page after initial ingest

### DIFF
--- a/client/pages/docs/import.vue
+++ b/client/pages/docs/import.vue
@@ -229,7 +229,7 @@ async function importSubmission () {
       title: 'Success',
       text: 'Document successfully added'
     })
-    await navigateTo(`/docs/${imported.name}/`)
+    await navigateTo(`/docs/${imported.name}/enqueue`)
   }
 }
 


### PR DESCRIPTION
Do we have any way to reverse paths so we're not hardcoding them into .vue files?

This stays with the current convention of not using trailing slashes.