### PR TITLE
feat: complexities heading group, sorting labels

### DIFF
--- a/client/components/DocLabelsCard.vue
+++ b/client/components/DocLabelsCard.vue
@@ -15,10 +15,11 @@
         :checked="selectedLabelIds?.includes(label.id ?? 0)"
         :class="[
           'pl-1 mb-1 pr-2 rounded-md text-xs font-medium ring-1 ring-inset text-xs',
-          label.color && badgeColors[label.color]
+          badgeColors[label.color ?? 'violet']
         ]"
         @change="handleCheckboxChange"
         size='small'
+        :title="label.slug"
       />
       <div v-else class="ml-0.5">
         <DocLabelsListbox v-model="selectedLabelIds!" :value="labelGroupRefs[slugGroup]" :labels="groupOfLabels" :slug-group="slugGroup.toString()" />
@@ -33,6 +34,7 @@ import type { Label } from '~/purple_client'
 import { SLUG_SEPARATOR, UNGROUPED } from '../utilities/labels'
 import { badgeColors } from '~/utilities/badge'
 import { assert } from '~/utilities/typescript'
+import { sortObject } from '~/utilities/sort'
 
 type Props = {
   title: string
@@ -68,12 +70,15 @@ const handleCheckboxChange = (e: Event) => {
 }
 
 
-const groupsOfLabels = computed(() => groupBy(
-  props.labels,
-  (label) => label.slug.includes(SLUG_SEPARATOR) ?
-              label.slug.substring(0, label.slug.indexOf(SLUG_SEPARATOR)) :
-              UNGROUPED
-))
+const groupsOfLabels = computed(() => sortObject(
+    groupBy(
+      props.labels,
+      (label) => label.slug.includes(SLUG_SEPARATOR) ?
+                  label.slug.substring(0, label.slug.indexOf(SLUG_SEPARATOR)) :
+                  UNGROUPED
+    )
+  )
+)
 
 const labelGroupRefs = computed(() => {
     assert(selectedLabelIds.value)

--- a/client/pages/docs/[id]/enqueue.vue
+++ b/client/pages/docs/[id]/enqueue.vue
@@ -9,16 +9,21 @@
     <div class="space-y-4">
       <DocInfoCard :draft="rfcToBe" />
       <div class="flex w-full space-x-4">
-        <DocLabelsCard
-          title="Complexities"
-          v-model="selectedLabelIds"
-          :labels="labels1"
-        />
-        <DocLabelsCard
-          title="Exceptions"
-          v-model="selectedLabelIds"
-          :labels="labels2"
-        />
+        <div class="flex flex-col">
+          <h2 class="font-bold text-lg border border-gray-200 pl-6 pt-4 pb-2 bg-white rounded-t-xl">Complexities</h2>
+          <div class="flex flex-row">
+            <DocLabelsCard
+              title="Other complexities"
+              v-model="selectedLabelIds"
+              :labels="labels1"
+            />
+            <DocLabelsCard
+              title="Exceptions"
+              v-model="selectedLabelIds"
+              :labels="labels2"
+            />
+          </div>
+        </div>
         <RpcLabelPicker
           item-label="slug"
           v-model="selectedLabelIds"

--- a/client/utilities/sort.ts
+++ b/client/utilities/sort.ts
@@ -1,0 +1,7 @@
+export const sortObject = <T extends Record<string, unknown>>(obj: T): T => {
+    return Object.keys(obj).sort().reduce(function (result, _key) {
+        const key: keyof T = _key
+        result[key] = obj[key];
+        return result;
+    }, {} as T);
+}


### PR DESCRIPTION
## feat

* Group the two columns of labels under a 'Complexities' heading,
![Screenshot_2025-06-27_14-49-39](https://github.com/user-attachments/assets/59b97fd9-af94-40a4-a72c-e5082db36c87)

This doesn't yet change the layout of the 3rd column of labels. That can happen in a later PR.

## fix

* the groups of labels (grouped by ":" prefixes) weren't ordered so the initial ungrouped list could appear in the middle of other groups, but now they're sorted so they'll always appear first.