### PR TITLE
fix: use draftNames in references API + admin fix

### DIFF
--- a/rpc/migrations/0017_blankable_rpcrelateddocument_targets.py
+++ b/rpc/migrations/0017_blankable_rpcrelateddocument_targets.py
@@ -1,0 +1,62 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("datatracker", "0002_initial"),
+        ("rpc", "0016_populate_doc_relationship_names"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="historicalrfctobe",
+            options={
+                "get_latest_by": ("history_date", "history_id"),
+                "ordering": ("-history_date", "-history_id"),
+                "verbose_name": "historical rfc to be",
+                "verbose_name_plural": "historical RfcToBes",
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="rfctobe",
+            options={"verbose_name_plural": "RfcToBes"},
+        ),
+        migrations.AlterField(
+            model_name="rpcrelateddocument",
+            name="target_document",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="rpcrelateddocument_target_set",
+                to="datatracker.document",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="rpcrelateddocument",
+            name="target_rfctobe",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="rpcrelateddocument_target_set",
+                to="rpc.rfctobe",
+            ),
+        ),
+        migrations.AlterConstraint(
+            model_name="rpcdocumentcomment",
+            name="rpcdocumentcomment_exactly_one_target",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    ("document__isnull", True),
+                    ("rfc_to_be__isnull", True),
+                    _connector="XOR",
+                ),
+                name="rpcdocumentcomment_exactly_one_target",
+                violation_error_message="exactly one of doc or rfc_to_be must be set",
+            ),
+        ),
+    ]

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -503,12 +503,14 @@ class RpcRelatedDocument(models.Model):
     source = models.ForeignKey(RfcToBe, on_delete=models.PROTECT)
     target_document = models.ForeignKey(
         "datatracker.Document",
+        blank=True,
         null=True,
         on_delete=models.PROTECT,
         related_name="rpcrelateddocument_target_set",
     )
     target_rfctobe = models.ForeignKey(
         RfcToBe,
+        blank=True,
         null=True,
         on_delete=models.PROTECT,
         related_name="rpcrelateddocument_target_set",

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -326,6 +326,22 @@ class CreateRfcToBeSerializer(serializers.ModelSerializer):
 class RpcRelatedDocumentSerializer(serializers.ModelSerializer):
     """Serializer for related document for an RfcToBe"""
 
+    target_draft_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = RpcRelatedDocument
+        fields = ["id", "relationship", "target_draft_name"]
+
+    def get_target_draft_name(self, obj: RpcRelatedDocument) -> str:
+        if obj.target_document is not None:
+            return obj.target_document.name
+        return obj.target_rfctobe.draft.name
+
+
+class CreateRpcRelatedDocumentSerializer(serializers.ModelSerializer):
+    """Serializer for creating a related document for an RfcToBe"""
+
+    # todo reconcile with refactored RpcRelatedDocumentSerializer
     class Meta:
         model = RpcRelatedDocument
         fields = ["id", "relationship", "source", "target_document", "target_rfctobe"]

--- a/rpc/utils.py
+++ b/rpc/utils.py
@@ -2,7 +2,7 @@
 from django.db.models import Max
 
 from .models import DumpInfo, RfcToBe, UnusableRfcNumber
-from .serializers import RpcRelatedDocumentSerializer
+from .serializers import CreateRpcRelatedDocumentSerializer
 
 
 class VersionInfo:
@@ -46,6 +46,7 @@ def create_rpc_related_document(
     else:
         raise ValueError(f"Invalid target type: {target_type}")
 
-    serializer = RpcRelatedDocumentSerializer(data=data)
+    serializer = CreateRpcRelatedDocumentSerializer(data=data)
     if serializer.is_valid(raise_exception=True):
         return serializer.save()
+    return None


### PR DESCRIPTION
Refactors part of the references API to make it partially usable by the front end. Fixes
* `documentsReferencesList()`
* `documentsReferencesRetrieve()`
but breaks (temporarily!)
* `documentsReferencesCreate()`
* `documentsReferencesUpdate()`
* `documentsReferencesPartialUpdate()`

Instead of serializing the models exactly, this sorts out which of `target_document` and `target_rfctobe` is set and serializes the name of that draft as `targetDraftName`. Drops fields that are redundant (mainly source, which is redundant with the draftName in the path parameter; also does not indicate whether the `targetDraftName` is an RfcToBe or Document - we may need to add that later, but it's currently redundant with the relationship type)

Also adds `blank=True` to the target fields in the model. This allows them to be created/updated in the admin interface.

This is a quick and dirty partial rework - we'll need further work cleaning up this API!