### PR TITLE
feat: create DTPerson for an RfcAuthor

### DIFF
--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -182,7 +182,12 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
 
 
 class CreateRfcAuthorSerializer(RfcAuthorSerializer):
+    # person_id is not a field on the model - remove it from validated_data
+    # before saving!
+    person_id = serializers.IntegerField(write_only=True)
+
     class Meta(RfcAuthorSerializer.Meta):
+        fields = RfcAuthorSerializer.Meta.fields + ["person_id"]
         read_only_fields = ["id"]
 
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -184,11 +184,12 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
 class CreateRfcAuthorSerializer(RfcAuthorSerializer):
     # person_id is not a field on the model - remove it from validated_data
     # before saving!
-    person_id = serializers.IntegerField(write_only=True)
+    person_id = serializers.IntegerField(
+        write_only=True, help_text="datatracker ID of a Person"
+    )
 
     class Meta(RfcAuthorSerializer.Meta):
         fields = RfcAuthorSerializer.Meta.fields + ["person_id"]
-        read_only_fields = ["id"]
 
 
 class AuthorOrderSerializer(serializers.Serializer):


### PR DESCRIPTION
Refactors the `documents_authors_create` API call to accept a `person_id` field, corresponding to a datatracker `Person` PK. If a `DatatrackerPerson` does not already exist, creates one.

This does not actually validate that the ID refers to a real person. It'd be easy to add such a call, but it's not clear it's necessary since an ID could (in theory) disappear during a person merge. The guard may lead to a false sense of security and I think it will be more robust to plan to deal with stale IDs more generally.