### PR TITLE
fix: config datatracker URL for nuxt

### DIFF
--- a/client/components/SidebarNav.vue
+++ b/client/components/SidebarNav.vue
@@ -88,7 +88,7 @@
             <span class="cursor-pointer select-none text-purple-50 dark:text-purple-950 hover:text-purple-500 dark:hover:text-purple-800 text-xs font-medium" @click="pi">π</span>
           </li>
           <li class="-mx-6">
-            <a href="https://datatracker.ietf.org" class="flex items-center gap-x-4 px-6 py-3 text-sm font-semibold leading-6 text-gray-500 dark:text-violet-400 hover:text-violet-500 dark:hover:text-violet-200 hover:bg-violet-500/5">
+            <a :href="$config.public.datatrackerBase" class="flex items-center gap-x-4 px-6 py-3 text-sm font-semibold leading-6 text-gray-500 dark:text-violet-400 hover:text-violet-500 dark:hover:text-violet-200 hover:bg-violet-500/5">
               <Icon name="solar:database-bold-duotone" class="h-8 w-8 opacity-70" aria-hidden="true" />
               <span>Go to Datatracker</span>
             </a>

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -36,7 +36,8 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
-      cspScriptSrcHashes: '' // comma-separated list
+      cspScriptSrcHashes: '', // comma-separated list
+      datatrackerBase: 'https://datatracker.ietf.org' // NUXT_PUBLIC_DATATRACKER_BASE
     }
   },
   security: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       # OIDC RP client credential for dev instance of datatracker (not secret for dev, will be for production)
       - PURPLE_OIDC_RP_CLIENT_ID=502412
       - PURPLE_OIDC_RP_CLIENT_SECRET=4046925638956f0d733cd96a5a89646815f0e989c878e9e09475b2f8
+      - NUXT_PUBLIC_DATATRACKER_BASE=http://localhost:8000
     depends_on:
       - db
     extra_hosts:

--- a/purple/settings/development.py
+++ b/purple/settings/development.py
@@ -17,7 +17,10 @@ ALLOWED_HOSTS = []
 DATATRACKER_RPC_API_TOKEN = os.environ["PURPLE_RPC_API_TOKEN"]
 DATATRACKER_RPC_API_BASE = "http://host.docker.internal:8000"
 DATATRACKER_API_V1_BASE = "http://host.docker.internal:8000/api/v1"
-DATATRACKER_BASE = "http://localhost:8000"
+DATATRACKER_BASE = os.environ.get(
+    "NUXT_PUBLIC_DATATRACKER_BASE",  # matches name used by Nuxt runtimeConfig
+    "http://localhost:8000",
+)
 
 
 # OIDC configuration (see also base.py)

--- a/purple/settings/production.py
+++ b/purple/settings/production.py
@@ -31,7 +31,7 @@ ALLOWED_HOSTS = _multiline_to_list(os.environ["PURPLE_ALLOWED_HOSTS"])
 # except PURPLE_RPC_API_TOKEN.
 DATATRACKER_RPC_API_TOKEN = os.environ["PURPLE_RPC_API_TOKEN"]
 DATATRACKER_BASE = os.environ.get(
-    "PURPLE_DATATRACKER_BASE", "https://datatracker.ietf.org"
+    "NUXT_PUBLIC_DATATRACKER_BASE", "https://datatracker.ietf.org"
 )
 DATATRACKER_RPC_API_BASE = os.environ.get(
     "PURPLE_DATATRACKER_RPC_API_BASE", f"{DATATRACKER_BASE}"


### PR DESCRIPTION
Add `datatrackerBase` to Nuxt's runtimeConfig.

The env var (and Vault key name) is changed from `PURPLE_DATATRACKER_BASE` to `NUXT_PUBLIC_DATATRACKER_BASE` and Django's settings are updated accordingly to keep the front and back ends consistent.