### PR TITLE
chore: fix settings BASE_PATH

### DIFF
--- a/purple/settings/base.py
+++ b/purple/settings/base.py
@@ -4,8 +4,7 @@
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
-
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/


### PR DESCRIPTION
The `BASE_PATH` computed in `settings/base.py` was meant to point at the project root. It seems not to have been updated correctly when we split `settings.py` into a module, and was instead pointing at the `purple` directory one level in. This came up because the Django templates were no longer working. It was looking in `purple/templates/` instead of just `templates/`.