### PR TITLE
fix: use Django's logout page for sign out

### DIFF
--- a/client/components/HeaderNav.vue
+++ b/client/components/HeaderNav.vue
@@ -105,11 +105,11 @@
                 <NuxtLink :to="item.href" :class="[active ? 'bg-gray-50' : '', 'block px-3 py-1 text-sm leading-6 text-gray-900']">{{ item.name }}</NuxtLink>
               </HeadlessMenuItem>
               <HeadlessMenuItem v-slot="{ active }">
-                <button
-                  :class="[active ? 'bg-gray-50' : '', 'block w-full px-3 py-1 text-sm leading-6 text-gray-900 text-left']"
-                  @click="logout()">
-                  Sign out
-                </button>
+                  <a
+                    href="/login/"
+                    :class="[active ? 'bg-gray-50' : '', 'block w-full px-3 py-1 text-sm leading-6 text-gray-900 text-left']">
+                    Sign out
+                  </a>
               </HeadlessMenuItem>
             </HeadlessMenuItems>
           </transition>
@@ -126,11 +126,6 @@ import { useUserStore } from '@/stores/user'
 const api = useApi()
 const csrf = useCookie('csrftoken', { sameSite: 'strict' })
 const buttonId = useId() // avoid a hydration error - see https://github.com/nuxt/ui/issues/1171
-
-async function logout () {
-  await $fetch('/oidc/logout/', { method: 'POST', headers: { 'X-CSRFToken': csrf.value! } })
-  userStore.refreshAuth()
-}
 
 // STORES
 


### PR DESCRIPTION
Navigates to `/login/` instead of using a JS fetch to sign out. The `/login/` page currently handles both login/logout.

WIP: the `/login/` path should be renamed, and the page is ancient proof-of-concept. This is a proof of concept right now, not at all ready for merge.