### PR TITLE
feat: DocRelationshipNames viewset

### DIFF
--- a/purple/urls.py
+++ b/purple/urls.py
@@ -77,6 +77,7 @@ router.register(
     basename="rpcperson-assignment",
 )
 router.register(r"rpc_roles", rpc_api.RpcRoleViewSet)
+router.register(r"doc_relationship_names", rpc_api.DocRelationshipNameViewSet)
 router.register(r"source_format_names", rpc_api.SourceFormatNameViewSet)
 router.register(r"std_level_names", rpc_api.StdLevelNameViewSet)
 router.register(r"stream_names", rpc_api.StreamNameViewSet)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -62,6 +62,7 @@ from .serializers import (
     CreateRfcAuthorSerializer,
     CreateRfcToBeSerializer,
     CreateRpcRelatedDocumentSerializer,
+    DocRelationshipNameSerializer,
     DocumentCommentSerializer,
     LabelSerializer,
     NestedAssignmentSerializer,
@@ -655,6 +656,11 @@ class StatsLabels(views.APIView):
                         }
                     )
         return Response({"label_stats": results})
+
+
+class DocRelationshipNameViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = DocRelationshipName.objects.all()
+    serializer_class = DocRelationshipNameSerializer
 
 
 class SourceFormatNameViewSet(viewsets.ReadOnlyModelViewSet):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -62,9 +62,9 @@ from .serializers import (
     CreateRfcAuthorSerializer,
     CreateRfcToBeSerializer,
     CreateRpcRelatedDocumentSerializer,
-    DocRelationshipNameSerializer,
     DocumentCommentSerializer,
     LabelSerializer,
+    NameSerializer,
     NestedAssignmentSerializer,
     QueueItemSerializer,
     RfcAuthorSerializer,
@@ -72,13 +72,9 @@ from .serializers import (
     RpcPersonSerializer,
     RpcRelatedDocumentSerializer,
     RpcRoleSerializer,
-    SourceFormatNameSerializer,
-    StdLevelNameSerializer,
-    StreamNameSerializer,
     Submission,
     SubmissionListItemSerializer,
     SubmissionSerializer,
-    TlpBoilerplateChoiceNameSerializer,
     VersionInfoSerializer,
     check_user_has_role,
 )
@@ -660,27 +656,27 @@ class StatsLabels(views.APIView):
 
 class DocRelationshipNameViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = DocRelationshipName.objects.all()
-    serializer_class = DocRelationshipNameSerializer
+    serializer_class = NameSerializer
 
 
 class SourceFormatNameViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = SourceFormatName.objects.all()
-    serializer_class = SourceFormatNameSerializer
+    serializer_class = NameSerializer
 
 
 class StdLevelNameViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = StdLevelName.objects.all()
-    serializer_class = StdLevelNameSerializer
+    serializer_class = NameSerializer
 
 
 class StreamNameViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = StreamName.objects.all()
-    serializer_class = StreamNameSerializer
+    serializer_class = NameSerializer
 
 
 class TlpBoilerplateChoiceNameViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = TlpBoilerplateChoiceName.objects.all()
-    serializer_class = TlpBoilerplateChoiceNameSerializer
+    serializer_class = NameSerializer
 
 
 @extend_schema_with_draft_name(actions=["list", "create", "update", "partial_update"])

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -22,6 +22,7 @@ from .models import (
     Cluster,
     ClusterMember,
     DispositionName,
+    DocRelationshipName,
     Label,
     RfcAuthor,
     RfcToBe,
@@ -612,6 +613,12 @@ class ClusterSerializer(serializers.ModelSerializer):
             "number",
             "documents",
         ]
+
+
+class DocRelationshipNameSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DocRelationshipName
+        fields = ["slug", "name", "desc"]
 
 
 class SourceFormatNameSerializer(serializers.ModelSerializer):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -22,7 +22,6 @@ from .models import (
     Cluster,
     ClusterMember,
     DispositionName,
-    DocRelationshipName,
     Label,
     RfcAuthor,
     RfcToBe,
@@ -615,34 +614,13 @@ class ClusterSerializer(serializers.ModelSerializer):
         ]
 
 
-class DocRelationshipNameSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = DocRelationshipName
-        fields = ["slug", "name", "desc"]
+class NameSerializer(serializers.Serializer):
+    """Serialize any Name subclass"""
 
-
-class SourceFormatNameSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = SourceFormatName
-        fields = ["slug", "name", "desc"]
-
-
-class StdLevelNameSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = StdLevelName
-        fields = ["slug", "name", "desc"]
-
-
-class StreamNameSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = StreamName
-        fields = ["slug", "name", "desc"]
-
-
-class TlpBoilerplateChoiceNameSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = SourceFormatName
-        fields = ["slug", "name", "desc"]
+    slug = serializers.CharField(max_length=32)
+    name = serializers.CharField(max_length=255)
+    desc = serializers.CharField(allow_blank=True)
+    used = serializers.BooleanField(default=True)
 
 
 @dataclass
@@ -703,13 +681,13 @@ class SubmissionSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     name = serializers.CharField()
     rev = serializers.CharField()
-    stream = StreamNameSerializer()
+    stream = NameSerializer()
     title = serializers.CharField()
     pages = serializers.IntegerField()
-    source_format = SourceFormatNameSerializer()
+    source_format = NameSerializer()
     authors = SubmissionAuthorSerializer(many=True)
     shepherd = serializers.EmailField()
-    std_level = StdLevelNameSerializer(required=False)
+    std_level = NameSerializer(required=False)
     datatracker_url = serializers.URLField()
 
 


### PR DESCRIPTION
Adds `DocRelationshipNamesList` and `DocRelationshipNamesRetrieve` API calls. Small refactor to use a common `NameSerializer` for subclasses of `models.Name` instead of maintaining a fleet of serializers identical but for name and model name.