### PR TITLE
feat: Aggregate queue tabs and add filter

### DIFF
--- a/client/components/DocumentTable.vue
+++ b/client/components/DocumentTable.vue
@@ -8,7 +8,7 @@
             v-for="col of columns"
             :key="col.key"
             scope="col"
-            class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-400"
+            class="px-3 py-3.5 text-left text-sm flex-inline content-start font-semibold text-gray-900 dark:text-neutral-400"
             :aria-sort="state.sortField === col.field ? state.sortDirection === 'asc' ? 'ascending' : 'descending' : undefined"
           >
             <button


### PR DESCRIPTION
## feat

* Merge queue tabs 'pending assignment', 'exceptions', and 'in process' into a new tab 'queue'
* add filters (I don't know how to move documents to this tab so I haven't tested this)
* vertically align `DocumentTable` `<th>`s

**screenshot**
<img width="1690" height="462" alt="Screenshot_2025-08-06_14-43-47" src="https://github.com/user-attachments/assets/2224d85d-a609-4409-bc96-eb628060b679" />
