### PR TITLE
feat: queue filter by labels

### DIFF
--- a/client/components/LabelsFilter.vue
+++ b/client/components/LabelsFilter.vue
@@ -1,0 +1,41 @@
+<template>
+  <div v-for="labelFilter in allLabelFilters">
+    <RpcCheckbox
+      :id="domIdBuilder(labelFilter.id)"
+      :label="labelFilter.slug"
+      size="small"
+      :checked="labelFilter.id && selectedLabelsTristate?.[labelFilter.id] ?
+        selectedLabelsTristate[labelFilter.id]:
+        CHECKBOX_INDETERMINATE"
+      :has-indeterminate="true"
+      @change="(tristate) => {
+        if(!selectedLabelsTristate || !labelFilter.id) {
+          console.warn('Can\'t update due to problem with selectedLabelsTristate or labelFilter.id', {
+            selectedLabelsTristate,
+            labelFilter
+          })
+          return
+        }
+        selectedLabelsTristate[labelFilter.id] = tristate
+      }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Label } from '~/purple_client'
+import { CHECKBOX_INDETERMINATE } from '~/utilities/checkbox'
+import type { CheckboxTristate } from '~/utilities/checkbox'
+
+const allLabelFilters = defineModel<Label[]>(
+  'all-label-filters',
+  { required: true }
+)
+
+const selectedLabelsTristate = defineModel<Record<number, CheckboxTristate>>(
+  'selected-label-filters',
+  { required: true }
+)
+
+const domIdBuilder = (id: number | undefined) => `labels-filter-${id}`
+</script>

--- a/client/utilities/checkbox.ts
+++ b/client/utilities/checkbox.ts
@@ -1,1 +1,3 @@
 export const CHECKBOX_INDETERMINATE = 'indeterminate' as const
+
+export type CheckboxTristate = boolean | typeof CHECKBOX_INDETERMINATE


### PR DESCRIPTION
## feat

* allows filtering by labels in the response (in the screenshot note the 'Label filters' section above the table)

I'll change the tristate checkbox UI in a subsequent PR

**screenshot**
<img width="1411" height="649" alt="Screenshot_2025-08-14_15-13-57" src="https://github.com/user-attachments/assets/0479ac8b-29e2-464e-a7d9-9b77d1ee4de1" />

Intentionally, this UI is a simple toggle list (rather than a more complicated [table column filter popout UI](https://i.imgur.com/LgA1F2R.png)) just to keep it simple for now. There are more filters to be added in subsequent PRs. Once we know all the filters we might revise it the overall filter UI.