### PR TITLE
refactor: clean up RfcToBe-related serializers

### DIFF
--- a/client/components/DocInfoCard.vue
+++ b/client/components/DocInfoCard.vue
@@ -3,16 +3,16 @@
     <template #header>
       <CardHeader title="Document Info" />
     </template>
-    <div v-if="draft">
+    <div v-if="rfcToBe">
       <DescriptionList>
-        <DescriptionListItem term="Title" :details="draft.title" />
+        <DescriptionListItem term="Title" :details="rfcToBe.title" />
         <DescriptionListItem term="Authors">
           <DescriptionListDetails>
             <div class="mx-4 text-sm font-medium">
-              <div v-if="draft.authors.length === 0">None</div>
+              <div v-if="rfcToBe.authors.length === 0">None</div>
               <div v-else>
                 <div
-                  v-for="author of draft.authors"
+                  v-for="author of rfcToBe.authors"
                   :key="author.id"
                   class="py-1 grid grid-cols-2"
                 >
@@ -27,7 +27,7 @@
         </DescriptionListItem>
         <DescriptionListItem
           term="Submitted Pages"
-          :details="draft.pages?.toString()"
+          :details="rfcToBe.draft.pages?.toString()"
         />
         <DescriptionListItem
           term="Document Shepherd"
@@ -35,9 +35,9 @@
         />
         <DescriptionListItem term="Stream">
           <DescriptionListDetails>
-            {{ draft.stream }}
-            <span v-if="draft.submittedStream !== draft.stream">
-              (submitted as {{ draft.submittedStream }})
+            {{ rfcToBe.intendedStream }}
+            <span v-if="rfcToBe.submittedStream !== rfcToBe.intendedStream">
+              (submitted as {{ rfcToBe.submittedStream }})
             </span>
           </DescriptionListDetails>
         </DescriptionListItem>
@@ -47,27 +47,27 @@
         />
         <DescriptionListItem
           term="Submitted Format"
-          :details="draft.submittedFormat"
+          :details="rfcToBe.submittedFormat"
         />
         <DescriptionListItem term="Submitted Boilerplate">
           <DescriptionListDetails
-            >{{ draft.intendedBoilerplate }}
+            >{{ rfcToBe.intendedBoilerplate }}
             <span
-              v-if="draft.submittedBoilerplate !== draft.intendedBoilerplate"
+              v-if="rfcToBe.submittedBoilerplate !== rfcToBe.intendedBoilerplate"
             >
-              (submitted as {{ draft.submittedBoilerplate }})
+              (submitted as {{ rfcToBe.submittedBoilerplate }})
             </span>
           </DescriptionListDetails>
         </DescriptionListItem>
         <DescriptionListItem term="Standard Level">
           <DescriptionListDetails>
-            {{ draft.intendedStdLevel }}
-            <span v-if="draft.submittedStdLevel !== draft.intendedStdLevel">
-              (submitted as {{ draft.submittedStdLevel }})
+            {{ rfcToBe.intendedStdLevel }}
+            <span v-if="rfcToBe.submittedStdLevel !== rfcToBe.intendedStdLevel">
+              (submitted as {{ rfcToBe.submittedStdLevel }})
             </span>
           </DescriptionListDetails>
         </DescriptionListItem>
-        <DescriptionListItem term="Disposition" :details="draft.disposition" />
+        <DescriptionListItem term="Disposition" :details="rfcToBe.disposition" />
       </DescriptionList>
     </div>
   </BaseCard>
@@ -77,7 +77,7 @@
 import type { RfcToBe } from '~/purple_client'
 
 type Props = {
-  draft: RfcToBe | null
+  rfcToBe: RfcToBe | null
 }
 
 defineProps<Props>()

--- a/client/components/ErrorAlert.vue
+++ b/client/components/ErrorAlert.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="rounded-md bg-red-50 p-4 dark:bg-red-500/15 dark:outline dark:outline-red-500/25">
+    <div class="flex">
+      <div class="ml-3">
+        <h3 class="text-sm font-medium text-red-800 dark:text-red-200">{{ title }}</h3>
+        <div class="mt-2 text-sm text-red-700 dark:text-red-200/80">
+          <slot/>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+type Props = { title: string }
+const props = withDefaults(defineProps<Props>(), { title: 'Error' })
+</script>

--- a/client/pages/docs/[id]/enqueue.vue
+++ b/client/pages/docs/[id]/enqueue.vue
@@ -5,7 +5,7 @@
 
     <div class="space-y-4">
       <div class="flex flex-row">
-        <DocInfoCard :draft="rfcToBe" />
+        <DocInfoCard :rfc-to-be="rfcToBe" />
         <EditAuthors v-if="rfcToBe" :draft-name="id" v-model="rfcToBe"/>
       </div>
 

--- a/client/pages/docs/[id]/index.vue
+++ b/client/pages/docs/[id]/index.vue
@@ -117,7 +117,7 @@
                </div>
              </div>
           </div>
-          <div v-else-if="historyStatus === 'success'" class="flex">
+          <div v-else-if="history && history.length > 0" class="flex">
             <table class="min-w-full divide-y divide-gray-300">
               <thead class="bg-gray-50 dark:bg-neutral-800">
               <tr>
@@ -176,7 +176,7 @@ const { data: history, status: historyStatus, refresh: historyRefresh } = await 
   { server: false, lazy: true }
 )
 
-const { data: rawRfcToBe, pending: rfcToBePending, refresh: rfcToBeRefresh } = await useAsyncData(
+const { data: rawRfcToBe, status: rfcToBeStatus } = await useAsyncData(
   () => `draft-${draftName.value}`,
   () => api.documentsRetrieve({ draftName: draftName.value }),
   { server: false }
@@ -221,10 +221,8 @@ watch(
   selectedLabelIds,
   async () => api.documentsPartialUpdate({
     draftName: draftName.value,
-    patchedRfcToBe: {
-      labels: selectedLabelIds.value,
-    }
-  }),
+    patchedRfcToBe: { labels: selectedLabelIds.value } }
+  ).finally(historyRefresh),
   { deep: true }
 )
 
@@ -239,14 +237,4 @@ const { data: people } = await useAsyncData(
   () => api.rpcPersonList(),
   { server: false, default: () => [] }
 )
-
-async function saveLabels (labels: number[]) {
-  if (!rfcToBePending.value) {
-    await api.documentsPartialUpdate({
-      draftName: rfcToBe.value?.name ?? '',
-      patchedRfcToBe: { labels }
-    })
-  }
-  rfcToBeRefresh()
-}
 </script>

--- a/client/pages/docs/[id]/index.vue
+++ b/client/pages/docs/[id]/index.vue
@@ -169,11 +169,8 @@ const draftName = computed(() => route.params.id.toString())
 
 const { data: history, status: historyStatus, refresh: historyRefresh } = await useAsyncData(
   () => `history-${draftName.value}`,
-  async () => {
-    const response = await api.documentsHistoryRetrieve({ draftName: draftName.value })
-    return response.history
-  },
-  { server: false, lazy: true }
+  () => api.documentsHistoryList({ draftName: draftName.value }),
+  { server: false, lazy: false }
 )
 
 const { data: rawRfcToBe, status: rfcToBeStatus } = await useAsyncData(

--- a/client/pages/docs/[id]/index.vue
+++ b/client/pages/docs/[id]/index.vue
@@ -25,10 +25,11 @@
     </header>
 
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <div v-if="rawRfcToBeError" class="bg-red-300 px-4 py-2 mb-4">
+      <ErrorAlert v-if="rawRfcToBeError" title="API Error">
         API error while requesting draft: {{ rawRfcToBeError }}
-      </div>
+      </ErrorAlert>
       <div
+        v-else
         class="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 place-items-stretch gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
 
         <!-- Status summary -->
@@ -113,16 +114,10 @@
             <Icon v-show="historyStatus === 'pending'" name="ei:spinner-3" size="1.5em" class="animate-spin" />
           </h3>
           <div v-if="historyStatus === 'error'">
-            <div class="rounded-md bg-yellow-50 p-4 dark:bg-yellow-500/10 dark:outline dark:outline-yellow-500/15">
-               <div class="flex">
-                 <div class="ml-3">
-                   <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-100">Error loading history</h3>
-                   <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-100/80">
-                     <p>Please try reloading and report the error if it persists.</p>
-                   </div>
-                 </div>
-               </div>
-             </div>
+            <ErrorAlert title="Error loading history">
+              <p v-if="historyError">{{ historyError }}</p>
+              <p v-else>Please try reloading and report the error if it persists.</p>
+            </ErrorAlert>
           </div>
           <div v-else-if="history && history.length > 0" class="flex">
             <table class="min-w-full divide-y divide-gray-300">
@@ -174,7 +169,7 @@ const api = useApi()
 
 const draftName = computed(() => route.params.id.toString())
 
-const { data: history, status: historyStatus, refresh: historyRefresh } = await useAsyncData(
+const { data: history, error: historyError, status: historyStatus, refresh: historyRefresh } = await useAsyncData(
   () => `history-${draftName.value}`,
   () => api.documentsHistoryList({ draftName: draftName.value }),
   { server: false, lazy: false }

--- a/client/pages/queue/[section].vue
+++ b/client/pages/queue/[section].vue
@@ -327,8 +327,9 @@ const columns = computed(() => {
       key: 'cluster',
       label: 'Cluster',
       field: 'cluster',
+      format: (value: any) => value?.number,
       icon: 'pajamas:group',
-      link: (val: any) => (val ? `/clusters/${val.cluster}` : '')
+      link: (val: any) => (val ? `/clusters/${val.cluster.number}` : '')
     })
   }
   if (currentTab.value === 'published') {

--- a/client/pages/team/[id].vue
+++ b/client/pages/team/[id].vue
@@ -17,8 +17,9 @@
               src="https://i.pravatar.cc/150?img=5" alt=""
               class="h-16 w-16 flex-none rounded-full ring-1 ring-gray-900/10">
             <h1>
-              <div class="mt-1 text-xl font-semibold leading-6 text-gray-900 dark:text-white">Ada Lovelace</div>
-              <div class="text-sm leading-6 text-gray-500 dark:text-neutral-400">ada.lovelace@ietf.org</div>
+              <span class="mt-1 text-xl font-semibold leading-6 text-gray-900 dark:text-white">Ada Lovelace</span>
+              <br>
+              <span class="text-sm leading-6 text-gray-500 dark:text-neutral-400">ada.lovelace@ietf.org</span>
             </h1>
           </div>
           <div class="flex items-center gap-x-4 sm:gap-x-6">

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -68,6 +68,7 @@ from .serializers import (
     NestedAssignmentSerializer,
     QueueItemSerializer,
     RfcAuthorSerializer,
+    RfcToBeHistorySerializer,
     RfcToBeSerializer,
     RpcPersonSerializer,
     RpcRelatedDocumentSerializer,
@@ -76,7 +77,7 @@ from .serializers import (
     SubmissionListItemSerializer,
     SubmissionSerializer,
     VersionInfoSerializer,
-    check_user_has_role, RfcToBeHistorySerializer,
+    check_user_has_role,
 )
 from .utils import VersionInfo, create_rpc_related_document, get_or_create_draft_by_name
 

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -76,7 +76,7 @@ from .serializers import (
     SubmissionListItemSerializer,
     SubmissionSerializer,
     VersionInfoSerializer,
-    check_user_has_role,
+    check_user_has_role, RfcToBeHistorySerializer,
 )
 from .utils import VersionInfo, create_rpc_related_document, get_or_create_draft_by_name
 
@@ -444,6 +444,13 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
     queryset = RfcToBe.objects.all()
     serializer_class = RfcToBeSerializer
     lookup_field = "draft__name"
+
+    @extend_schema(responses=RfcToBeHistorySerializer)
+    @action(detail=True)
+    def history(self, request, draft__name=None):
+        rfc_to_be = self.get_object()
+        serializer = RfcToBeHistorySerializer(rfc_to_be)
+        return Response(serializer.data)
 
 
 @extend_schema_with_draft_name()

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -445,11 +445,11 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
     serializer_class = RfcToBeSerializer
     lookup_field = "draft__name"
 
-    @extend_schema(responses=RfcToBeHistorySerializer)
+    @extend_schema(responses=RfcToBeHistorySerializer(many=True))
     @action(detail=True)
     def history(self, request, draft__name=None):
         rfc_to_be = self.get_object()
-        serializer = RfcToBeHistorySerializer(rfc_to_be)
+        serializer = RfcToBeHistorySerializer(rfc_to_be.history, many=True)
         return Response(serializer.data)
 
 

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1,6 +1,7 @@
 # Copyright The IETF Trust 2023-2025, All Rights Reserved
 
 import datetime
+import logging
 from dataclasses import dataclass
 from itertools import pairwise
 
@@ -17,6 +18,8 @@ from .dt_v1_api_utils import (
     datatracker_streamname,
 )
 from .rules import is_comment_author, is_rpc_person
+
+logger = logging.getLogger(__name__)
 
 
 class DumpInfo(models.Model):
@@ -122,6 +125,30 @@ class RfcToBe(models.Model):
         return (
             f"RfcToBe for {self.draft if self.rfc_number is None else self.rfc_number}"
         )
+
+    def _warn_if_not_april1_rfc(self):
+        """Emit a warning if called with a non-April-first RFC"""
+        if not self.is_april_first_rfc:
+            logger.warning(
+                f"Warning! RfcToBe(pk={self.pk}) has no draft and is not an April 1st RFC"
+            )
+
+    # Properties that we currently only get from our draft
+    @property
+    def name(self) -> str:
+        if self.draft:
+            return self.draft.name
+        self._warn_if_not_april1_rfc()
+        if self.rfc_number is not None:
+            return f"RFC {self.rfc_number}"
+        return f"<RfcToBe {self.pk}>"
+
+    @property
+    def title(self) -> str:
+        if self.draft:
+            return self.draft.title
+        self._warn_if_not_april1_rfc()
+        return "<No title>"
 
     @dataclass
     class Interval:

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -150,6 +150,11 @@ class RfcToBe(models.Model):
         self._warn_if_not_april1_rfc()
         return "<No title>"
 
+    # Easier interface to the cluster_set
+    @property
+    def cluster(self) -> "Cluster | None":
+        return self.draft.cluster_set.first() if self.draft else None
+
     @dataclass
     class Interval:
         start: datetime.datetime

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -130,7 +130,8 @@ class RfcToBe(models.Model):
         """Emit a warning if called with a non-April-first RFC"""
         if not self.is_april_first_rfc:
             logger.warning(
-                f"Warning! RfcToBe(pk={self.pk}) has no draft and is not an April 1st RFC"
+                f"Warning! RfcToBe(pk={self.pk}) has no draft "
+                "and is not an April 1st RFC"
             )
 
     # Properties that we currently only get from our draft

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -530,7 +530,6 @@ class QueueItemSerializer(serializers.ModelSerializer):
     actionholder_set = ActionHolderSerializer(
         source="actionholder_set.active", many=True, read_only=True
     )
-    requested_approvals = serializers.SerializerMethodField()
     pending_activities = RpcRoleSerializer(many=True, read_only=True)
 
     class Meta:
@@ -546,12 +545,8 @@ class QueueItemSerializer(serializers.ModelSerializer):
             "labels",
             "assignment_set",
             "actionholder_set",
-            "requested_approvals",
             "pending_activities",
         ]
-
-    def get_requested_approvals(self, rfc_to_be) -> list:
-        return []  # todo return a value
 
 
 class ClusterMemberListSerializer(serializers.ListSerializer):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -274,11 +274,6 @@ class RfcToBeSerializer(serializers.ModelSerializer):
             return None if cluster is None else cluster.number
         return None  # RfcToBe without draft cannot be a cluster member
 
-    def create(self, validated_data):
-        inst = super().create(validated_data)
-        update_change_reason(inst, "Added to the queue")
-        return inst
-
 
 class RfcToBeHistorySerializer(HistorySerializer):
     def describe_model_delta(self, delta: ModelDelta):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -89,6 +89,13 @@ class HistoryRecord:
 
 
 class HistoryListSerializer(serializers.ListSerializer):
+    @staticmethod
+    def _default_model_change_description(delta):
+        return (
+            f"{change.field} changed from {change.old} to {change.new}"
+            for change in delta.changes
+        )
+
     def describe_model_delta(self, delta: ModelDelta):
         method_name = "describe_model_delta"
         if hasattr(self.parent, method_name):
@@ -96,10 +103,7 @@ class HistoryListSerializer(serializers.ListSerializer):
         elif hasattr(self.child, method_name):
             method = getattr(self.child, method_name)
         else:
-            method = lambda change: (
-                f"{change.field} changed from {change.old} to {change.new}"
-                for change in delta.changes
-            )
+            return self._default_model_change_description
         return method(delta)
 
     def to_representation(self, data):


### PR DESCRIPTION
This reorganizes and adjusts the `RfcToBeSerializer` and `QueueItemSerializer` and related smaller serializers. Surrounding code is refactored to work with the changes. Highlights:

  * Splits the history serialization out of `RfcToBeSerializer`
    - adds `documentsHistoryList` API call to fetch only the history for a draft (n.b., the commit comment below calls it `...Retrieve`, but subsequent refactors changed it to `...List`)
    - adjusts the document index page to refresh history after adding labels
  * Eliminates all of the `SerializerMethodField` fields from these serializers in favor of cleaner options
  * Adds missing fields that seem logical for the two serializers
    - Added `actionholder_set` and `assignment_set` to `RfcToBeSerializer`
    - Added a few easily computed fields likely to be wanted on a queue-like page to `QueueItemSerializer`
  * Reorganized `serializers.py` to make this all work