### PR TITLE
feat: label management improvements

### DIFF
--- a/client/components/RpcLabelEditDialog.vue
+++ b/client/components/RpcLabelEditDialog.vue
@@ -102,11 +102,10 @@ type Props = {
 }
 
 const props = defineProps<Props>()
-const label = reactive(props.label)
+const label = reactive<Label>({ ...props.label })
 
-async function save () {
+async function save() {
   const labelData: Label = {
-    id: 0, // FIXME: is this ok?
     slug: label.slug,
     isException: label.isException,
     isComplexity: label.isComplexity,

--- a/client/components/RpcLabelEditDialog.vue
+++ b/client/components/RpcLabelEditDialog.vue
@@ -96,26 +96,17 @@ if (!_overlayModalMethods) {
 const { ok, cancel } = _overlayModalMethods
 const snackbar = useSnackbar()
 
-type Props = {
-  label: Label
-  create: boolean
-}
+type Props = { label: Label }
 
 const props = defineProps<Props>()
 const label = reactive<Label>({ ...props.label })
 
 async function save() {
-  const labelData: Label = {
-    slug: label.slug,
-    isException: label.isException,
-    isComplexity: label.isComplexity,
-    color: label.color
-  }
   try {
-    if (props.create) {
-      await api.labelsCreate({ label: labelData })
+    if (label.id === undefined) {
+      await api.labelsCreate({ label })
     } else {
-      await api.labelsUpdate({ id: label.id, label: labelData })
+      await api.labelsUpdate({ id: label.id, label })
     }
   } catch {
     snackbar.add({

--- a/client/components/RpcLabelEditDialog.vue
+++ b/client/components/RpcLabelEditDialog.vue
@@ -96,10 +96,13 @@ if (!_overlayModalMethods) {
 const { ok, cancel } = _overlayModalMethods
 const snackbar = useSnackbar()
 
-type Props = { label: Label }
-
+type Props = { label: Label | undefined }
 const props = defineProps<Props>()
-const label = reactive<Label>({ ...props.label })
+
+const NEW_LABEL_DEFAULTS: Label = { slug: '', isException: false, color: 'slate' }
+const label = reactive<Label>(
+  props.label ? { ...props.label } : NEW_LABEL_DEFAULTS
+)
 
 async function save() {
   try {

--- a/client/components/RpcLabelEditDialog.vue
+++ b/client/components/RpcLabelEditDialog.vue
@@ -43,8 +43,9 @@
         </div>
 
         <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-          <label for="is-exception" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">Is
-            Exception</label>
+          <label for="is-exception" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">
+            Is Exception
+          </label>
           <div class="mt-2 sm:col-span-2 sm:mt-0">
             <input
               id="is-exception" v-model="label.isException" name="is-exception" type="checkbox"
@@ -54,8 +55,9 @@
         </div>
 
         <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-          <label for="is-complexity" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">Is
-            Complexity</label>
+          <label for="is-complexity" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">
+            Is Complexity
+          </label>
           <div class="mt-2 sm:col-span-2 sm:mt-0">
             <input
               id="is-complexity" v-model="label.isComplexity" name="is-complexity" type="checkbox"
@@ -75,8 +77,18 @@
           </div>
         </div>
 
+        <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
+          <label for="is-used" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">
+            May be Used
+          </label>
+          <div class="mt-2 sm:col-span-2 sm:mt-0">
+            <input
+              id="is-used" v-model="label.used" name="is-used" type="checkbox"
+              class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
+            <p class="text-gray-500">This label is still in use.</p>
+          </div>
+        </div>
       </div>
-
     </div>
 
   </form>
@@ -99,7 +111,13 @@ const snackbar = useSnackbar()
 type Props = { label: Label | undefined }
 const props = defineProps<Props>()
 
-const NEW_LABEL_DEFAULTS: Label = { slug: '', isException: false, color: 'slate' }
+const NEW_LABEL_DEFAULTS: Label = {
+  slug: '',
+  isException: false,
+  color: 'slate',
+  used: true
+}
+
 const label = reactive<Label>(
   props.label ? { ...props.label } : NEW_LABEL_DEFAULTS
 )

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -32,6 +32,7 @@
               <tr v-for="label in sortedLabels" :key="label.slug">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                   <RpcLabel :label="label"/>
+                  <Icon v-if="!label.used" name="heroicons:x-mark-solid" class="text-red-500"/>
                 </td>
                 <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                   <Icon

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -73,8 +73,8 @@ async function addLabel () {
     await openOverlayModal({
       component: RpcLabelEditDialog,
       componentProps: {
-        label: { slug: '', isException: false, color: 'slate' },
-        create: true
+        // absent id => create a new label
+        label: { slug: '', isException: false, color: 'slate' }
       }
     })
   } catch {

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -70,13 +70,8 @@ const { openOverlayModal } = val
 
 async function addLabel () {
   try {
-    await openOverlayModal({
-      component: RpcLabelEditDialog,
-      componentProps: {
-        // absent id => create a new label
-        label: { slug: '', isException: false, color: 'slate' }
-      }
-    })
+    // Empty componentProps => create a new label
+    await openOverlayModal({ component: RpcLabelEditDialog })
   } catch {
     snackbar.add({
       type: 'info',

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -8,7 +8,10 @@
         <button type="button" class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" @click="addLabel()">Add Label</button>
       </div>
     </div>
-    <div class="mt-8 flow-root">
+    <ErrorAlert v-if="labelsError" title="API Error">
+      API error while requesting labels: {{ labelsError }}
+    </ErrorAlert>
+    <div v-else class="mt-8 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-fit py-2 align-middle sm:px-6 lg:px-8">
           <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
@@ -47,18 +50,8 @@ const snackbar = useSnackbar()
 
 const sortedLabels = computed(() => labels.value?.toSorted((a, b) => a.slug.localeCompare(b.slug, 'en')) ?? [])
 
-const { data: labels, refresh } = await useAsyncData(
-  async () => {
-    try {
-      return await api.labelsList()
-    } catch (error) {
-      snackbar.add({
-        type: 'error',
-        title: 'Fetch Failed',
-        text: error
-      })
-    }
-  },
+const { data: labels, error: labelsError, refresh } = await useAsyncData(
+  () => api.labelsList(),
   { server: false }
 )
 

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -5,7 +5,11 @@
         <h1 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-300">Labels</h1>
       </div>
       <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-        <button type="button" class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" @click="addLabel()">Add Label</button>
+        <button
+          type="button"
+          class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          @click="addLabel()">Add Label
+        </button>
       </div>
     </div>
     <ErrorAlert v-if="labelsError" title="API Error">
@@ -17,20 +21,25 @@
           <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
             <table class="min-w-fit divide-y divide-gray-300">
               <thead class="bg-gray-50">
-                <tr>
-                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-                  <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                    <span class="sr-only">Edit</span>
-                  </th>
-                </tr>
+              <tr>
+                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
+                <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                  <span class="sr-only">Edit</span>
+                </th>
+              </tr>
               </thead>
               <tbody class="divide-y divide-gray-200 bg-white">
-                <tr v-for="label in sortedLabels" :key="label.slug">
-                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><RpcLabel :label="label"/></td>
-                  <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                    <Icon name="circum:edit" class="text-indigo-600 hover:text-indigo-900 cursor-pointer"  @click="editLabel(label)" /><span class="sr-only">Edit {{ label.slug }}</span>
-                  </td>
-                </tr>
+              <tr v-for="label in sortedLabels" :key="label.slug">
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                  <RpcLabel :label="label"/>
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <Icon
+                    name="circum:edit" class="text-indigo-600 hover:text-indigo-900 cursor-pointer"
+                    @click="editLabel(label)"/>
+                  <span class="sr-only">Edit {{ label.slug }}</span>
+                </td>
+              </tr>
               </tbody>
             </table>
           </div>
@@ -61,7 +70,7 @@ if (!val) {
 }
 const { openOverlayModal } = val
 
-async function addLabel () {
+async function addLabel() {
   try {
     // Empty componentProps => create a new label
     await openOverlayModal({ component: RpcLabelEditDialog })
@@ -83,7 +92,7 @@ async function addLabel () {
   }
 }
 
-async function editLabel (label: Label) {
+async function editLabel(label: Label) {
   try {
     await openOverlayModal({
       component: RpcLabelEditDialog,


### PR DESCRIPTION
Feature-wise, this exposes the "used" flag through the "manage labels" page. Cleans up some reactivity / state management / error displays to be more in line with how we've evolved. There's more cleanup to be done.

Adds a very simple red "X" mark on the label list display to indicate labels with used = False. This will need to be improved, but it's more than I have time for now.