### PR TITLE
feat: show assignments and pend activities

### DIFF
--- a/client/components/DocumentDependencies.vue
+++ b/client/components/DocumentDependencies.vue
@@ -22,16 +22,12 @@
 <script setup lang="ts">
 import type { RpcRelatedDocument } from '~/purple_client';
 import type { Column } from './DocumentTableTypes';
+import { h } from 'vue'
+import BaseBadge from './BaseBadge.vue'
 
 const relatedDocuments = defineModel<RpcRelatedDocument[]>({ default: [] })
 
 const columns: Column[] = [
-  {
-    key: 'name',
-    label: 'Document',
-    field: 'id' satisfies keyof RpcRelatedDocument,
-    classes: 'text-sm font-medium'
-  },
   {
     key: 'relationship',
     label: 'Relationship',
@@ -43,6 +39,47 @@ const columns: Column[] = [
     label: 'Current State',
     field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
     classes: 'text-sm font-medium'
+  },
+  {
+    key: 'currentAssignments',
+    label: 'Current Assignments',
+    field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
+    classes: 'text-sm font-medium',
+    format: (row: any) => {
+      const info = props.relatedDocsInfo?.[row] || {}
+      const assignments = info.assignment_set
+      if (!assignments || !Array.isArray(assignments) || assignments.length === 0) return '—'
+      const nodes = []
+      assignments.forEach((assignment: any, idx: number) => {
+        const person = (props.people || []).find((p: any) => p.id === assignment.person)
+        nodes.push(
+          h('span', [
+            h(BaseBadge, { label: assignment.role }),
+            ' ',
+            person ? `(${person.name})` : ''
+          ])
+        )
+        if (idx < assignments.length - 1) nodes.push(', ')
+      })
+      return nodes
+    }
+  },
+  {
+    key: 'pendingActivities',
+    label: 'Pending Activities',
+    field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
+    classes: 'text-sm font-medium',
+    format: (row: any) => {
+      const info = props.relatedDocsInfo?.[row] || {}
+      const pending = info.pending_activities
+      if (!pending || !Array.isArray(pending) || pending.length === 0) return '—'
+      const nodes = []
+      pending.forEach((a: any, idx: number) => {
+        nodes.push(h(BaseBadge, { label: a.name }))
+        if (idx < pending.length - 1) nodes.push(', ')
+      })
+      return nodes
+    }
   }
 ]
 
@@ -51,6 +88,8 @@ const isOpenDependencyModal = ref(false)
 type Props = {
   draftName: string
   id: number,
+  relatedDocsInfo: Record<string, { assignment_set?: any; pending_activities?: any }>
+  people: any[]
 }
 
 const props = defineProps<Props>()

--- a/client/components/DocumentDependencies.vue
+++ b/client/components/DocumentDependencies.vue
@@ -35,13 +35,13 @@ const columns: Column[] = [
     classes: 'text-sm font-medium'
   },
   {
-    key: 'currentState',
-    label: 'Current State',
+    key: 'targetDraftName',
+    label: 'Target Draft Name',
     field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
     classes: 'text-sm font-medium'
   },
   {
-    key: 'currentAssignments',
+    key: 'pendingActivities',
     label: 'Current Assignments',
     field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
     classes: 'text-sm font-medium',
@@ -49,7 +49,7 @@ const columns: Column[] = [
       const info = props.relatedDocsInfo?.[row] || {}
       const assignments = info.assignment_set
       if (!assignments || !Array.isArray(assignments) || assignments.length === 0) return '—'
-      const nodes = []
+      const nodes: (string | VNode)[] = []
       assignments.forEach((assignment: any, idx: number) => {
         const person = (props.people || []).find((p: any) => p.id === assignment.person)
         nodes.push(
@@ -73,12 +73,32 @@ const columns: Column[] = [
       const info = props.relatedDocsInfo?.[row] || {}
       const pending = info.pending_activities
       if (!pending || !Array.isArray(pending) || pending.length === 0) return '—'
-      const nodes = []
+      const nodes: (string | VNode)[] = []
       pending.forEach((a: any, idx: number) => {
         nodes.push(h(BaseBadge, { label: a.name }))
         if (idx < pending.length - 1) nodes.push(', ')
       })
       return nodes
+    }
+  },
+  {
+    key: 'notReceivedCount',
+    label: 'not received #',
+    field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
+    classes: 'text-sm font-medium',
+    format: (row: any) => {
+      const info = props.relatedDocsInfo?.[row] || {}
+      return info.not_received_count || 0
+    }
+  },
+    {
+    key: 'refqueueCount',
+    label: 'refqueue #',
+    field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
+    classes: 'text-sm font-medium',
+    format: (row: any) => {
+      const info = props.relatedDocsInfo?.[row] || {}
+      return info.refqueue_count || 0
     }
   }
 ]
@@ -88,7 +108,12 @@ const isOpenDependencyModal = ref(false)
 type Props = {
   draftName: string
   id: number,
-  relatedDocsInfo: Record<string, { assignment_set?: any; pending_activities?: any }>
+  relatedDocsInfo: Record<string, {
+    assignment_set?: any;
+    pending_activities?: any;
+    refqueue_count?: any;
+    not_received_count?: any;
+  }>
   people: any[]
 }
 

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -374,7 +374,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                                 "intended_std_level": draft_info.intended_std_level,
                             },
                         )
-                    create_rpc_related_document("missref", rfctobe.pk, draft.name)
+                    create_rpc_related_document("not-received", rfctobe.pk, draft.name)
                 else:
                     disposition = existing_rfc_to_be[reference.id]
                     if disposition in ("created", "in_progress"):
@@ -565,7 +565,7 @@ class RpcRelatedDocumentViewSet(viewsets.ModelViewSet):
             OpenApiExample(
                 "Create Related Document",
                 value={
-                    "relationship": "missref",
+                    "relationship": "not-received",
                     "target_draft_name": "draft-lorem-ipsum-dolor-sit-amet",
                 },
                 request_only=True,
@@ -574,7 +574,7 @@ class RpcRelatedDocumentViewSet(viewsets.ModelViewSet):
                 "Created Related Document Response",
                 value={
                     "id": 1,
-                    "relationship": "missref",
+                    "relationship": "not-received",
                     "draft_name": "draft-source-document",
                     "target_draft_name": "draft-lorem-ipsum-dolor-sit-amet",
                 },

--- a/rpc/migrations/0006_populate_doc_relationship_names.py
+++ b/rpc/migrations/0006_populate_doc_relationship_names.py
@@ -7,8 +7,8 @@ def forward(apps, schema_editor):
     DocRelationshipName = apps.get_model("rpc", "DocRelationshipName")
 
     DocRelationshipName.objects.create(
-        slug="missref",
-        name="Missing reference",
+        slug="not-received",
+        name="Not Received",
         desc="Normative reference to a document that is still in draft state",
         used=True,
     )
@@ -31,7 +31,7 @@ def forward(apps, schema_editor):
 def reverse(apps, schema_editor):
     DocRelationshipName = apps.get_model("rpc", "DocRelationshipName")
     DocRelationshipName.objects.filter(
-        slug__in=["missref", "refqueue", "withdrawnref"]
+        slug__in=["not-received", "refqueue", "withdrawnref"]
     ).delete()
 
 


### PR DESCRIPTION
for each related doc, call API for additional info, filter out assignments and pending_activities and pass them to component

@holloway I didn't change the API-payload, but added additional API calls to fetch draft details. Let me know what you think of this approach

<img width="880" height="352" alt="image" src="https://github.com/user-attachments/assets/64eff8f9-e904-4047-9a4b-acef855c4dd9" />
