### PR TITLE
chore: tristate button toggles through 'mixed' / true / false rather …

### DIFF
--- a/client/components/RpcTristateButton.vue
+++ b/client/components/RpcTristateButton.vue
@@ -1,25 +1,19 @@
 <template>
-  <div
-    v-bind="$attrs"
+  <div v-bind="$attrs"
     :class="['flex gap-1 p-1 text-xs cursor-pointer rounded-sm shadow text-gray-800 dark:text-white bg-white dark:bg-neutral-700 outline outline-1 outline-gray-300 dark:outline-gray-400 focus-within:outline-2 focus-within:outline-purple-600 focus-within:outline-purple-600 dark:focus-within:outline-white ', props.class]"
-    @click="handleChange"
-  >
+    @click="handleChange">
     <span :class="{
       'block w-5 h-5 text-center font-semibold font-mono shadow-inner dark:shadow-none border rounded-sm pt-[0.2em]': true,
       'bg-green-100 border-gray-500 shadow-gray-300 text-green-700': props.checked === true,
       'bg-red-100 border-red-600 shadow-gray-300 text-red-800': props.checked === false,
-      'bg-transparent border-gray-400 shadow-gray-200': props.checked === 'mixed',
+      'bg-transparent border-gray-400 shadow-gray-200': props.checked === TRISTATE_MIXED,
     }">
       <span v-if="props.checked === true">Y</span>
       <span v-else-if="props.checked === false">N</span>
       <span v-else-if="props.checked === TRISTATE_MIXED">&nbsp;</span>
     </span>
-    <button
-      ref="button"
-      type="button"
-      :aria-pressed="props.checked"
-      class="border-0 bg-transparent focus:border-0 focus:outline-0 pl-1 pr-1"
-    >
+    <button ref="button" type="button" :aria-pressed="props.checked"
+      class="border-0 bg-transparent focus:border-0 focus:outline-0 pl-1 pr-1">
       <slot />
     </button>
   </div>
@@ -49,18 +43,26 @@ const button = useTemplateRef('button')
 
 // COMPUTED
 
-const checkCounter = ref<number>(props.checked === TRISTATE_MIXED ? 2 : props.checked ? 1 : 0)
+const intToTristate = (int: number): TristateValue => {
+  // Use modulus to track clicks
+  // mod3 === 0 is true
+  // mod3 === 1 is false
+  // mod3 === 2 is 'mixed'
+  const mod3 = int % 3
+  return mod3 === 2 ? TRISTATE_MIXED : mod3 === 0 ? true : false
+}
+
+const tristateToInt = (tristate: TristateValue): number => {
+  return tristate === TRISTATE_MIXED ? 2 : tristate ? 0 : 1
+}
+
+const checkCounter = ref<number>(tristateToInt(props.checked))
 
 const handleChange = () => {
   button.value?.focus()
   // use our internal state instead of event.target.checked state
   checkCounter.value++
-  // Use modulus to track clicks
-  // mod3 === 0 is false
-  // mod3 === 1 is true
-  // mod3 === 2 is indeterminate see
-  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/indeterminate
-  const mod3 = checkCounter.value % 3
-  emit('change', mod3 === 2 ? TRISTATE_MIXED : Boolean(mod3))
+  emit('change', intToTristate(checkCounter.value))
 }
+
 </script>


### PR DESCRIPTION
## chore

* minor tweak to tristate button so it toggles through 'mixed' :arrow_right: `true` :arrow_right: `false` (rather than 'mixed' :arrow_right: `false` :arrow_right: `true`)