### PR TITLE
feat: add cluster info

### DIFF
--- a/client/components/DocInfoCard.vue
+++ b/client/components/DocInfoCard.vue
@@ -68,7 +68,6 @@
           </DescriptionListDetails>
         </DescriptionListItem>
         <DescriptionListItem term="Disposition" :details="rfcToBe.disposition" />
-        <DescriptionListItem term="Cluster" :details="rfcToBe.cluster.number" />
       </DescriptionList>
     </div>
   </BaseCard>

--- a/client/components/DocInfoCard.vue
+++ b/client/components/DocInfoCard.vue
@@ -68,6 +68,7 @@
           </DescriptionListDetails>
         </DescriptionListItem>
         <DescriptionListItem term="Disposition" :details="rfcToBe.disposition" />
+        <DescriptionListItem term="Cluster" :details="rfcToBe.cluster.number" />
       </DescriptionList>
     </div>
   </BaseCard>

--- a/client/components/DocumentDependencies.vue
+++ b/client/components/DocumentDependencies.vue
@@ -8,6 +8,17 @@
           </template>
         </CardHeader>
       </template>
+      <div class="flex items-center gap-2 mb-4">
+        <span class="font-medium">Cluster: </span>
+        <span class="mr-2">
+          <span v-if="props.clusterNumber">
+            <NuxtLink :to="`/clusters/${props.clusterNumber}`" class="inline-flex items-center gap-1 text-blue-600">
+              <Icon name="pajamas:group" class="h-5 w-5" />{{ props.clusterNumber }}
+            </NuxtLink>
+          </span>
+        <span v-else>-</span>
+        </span>
+      </div>
       <DocumentTable v-if="relatedDocuments" :columns="columns" :data="relatedDocuments" row-key="id" />
     </BaseCard>
     <DocumentDependenciesAdd
@@ -16,13 +27,14 @@
       :draft-name="props.draftName"
       :id="props.id"
     />
-  </div>
+</div>
 </template>
 
 <script setup lang="ts">
 import type { RpcRelatedDocument } from '~/purple_client';
 import type { Column } from './DocumentTableTypes';
 import { h } from 'vue'
+import { NuxtLink } from '#components'
 import BaseBadge from './BaseBadge.vue'
 
 const relatedDocuments = defineModel<RpcRelatedDocument[]>({ default: [] })
@@ -38,7 +50,13 @@ const columns: Column[] = [
     key: 'targetDraftName',
     label: 'Target Draft Name',
     field: 'targetDraftName' satisfies keyof RpcRelatedDocument,
-    classes: 'text-sm font-medium'
+    classes: 'text-sm font-medium',
+    format: (row: any) => {
+      return h(NuxtLink, {
+        to: `/docs/${row}`,
+        class: 'inline-flex items-center gap-1 text-blue-600'
+      }, row)
+    }
   },
   {
     key: 'pendingActivities',
@@ -108,7 +126,8 @@ const isOpenDependencyModal = ref(false)
 type Props = {
   draftName: string
   id: number,
-  people?: any[]
+  people?: any[],
+  clusterNumber?: number
 }
 
 const api = useApi()

--- a/client/pages/docs/[id]/enqueue.vue
+++ b/client/pages/docs/[id]/enqueue.vue
@@ -26,7 +26,11 @@
         </div>
       </div>
       <div v-if="rfcToBe?.id">
-        <DocumentDependencies v-model="relatedDocuments" :id="rfcToBe.id" :draft-name="id"></DocumentDependencies>
+        <DocumentDependencies v-model="relatedDocuments"
+                              :id="rfcToBe.id"
+                              :draft-name="id"
+                              :cluster-number="rfcToBe.cluster?.number">
+        </DocumentDependencies>
       </div>
       <BaseCard>
         <template #header>

--- a/client/pages/docs/[id]/index.vue
+++ b/client/pages/docs/[id]/index.vue
@@ -107,7 +107,8 @@
           <DocumentDependencies v-model="relatedDocuments"
                                 :id="rawRfcToBe.id"
                                 :draft-name="draftName"
-                                :people="people">
+                                :people="people"
+                                :cluster-number="rawRfcToBe.cluster?.number">
           </DocumentDependencies>
         </div>
 


### PR DESCRIPTION
<img width="613" height="438" alt="image" src="https://github.com/user-attachments/assets/632c83dd-a24f-4922-bc37-93bd25694ba6" />

- show cluster number
- cluster number links to cluster info page
- make the related docs a link to their respective draft info page