### PR TITLE
fix timezone warning

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.db.models import Max, Q
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from django_filters import rest_framework as filters
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
@@ -501,9 +502,7 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
         if form.is_valid():
             days = form.cleaned_data.get("published_within_days")
             if days is not None:
-                days_ago_limit = datetime.datetime.now() - datetime.timedelta(
-                    days=int(days)
-                )
+                days_ago_limit = timezone.now() - datetime.timedelta(days=int(days))
                 queryset = queryset.filter(published_at__gte=days_ago_limit)
         else:
             raise serializers.ValidationError(form.errors)


### PR DESCRIPTION
fixes issue
```
/home/dev/.local/lib/python3.12/site-packages/django/db/models/fields/init.py:1671: RuntimeWarning: DateTimeField RfcToBe.published_at received a naive datetime (2025-08-04 15:00:55.586615) while time zone support is active.
warnings.warn(
[03/Oct/2025 15:00:55] "GET /api/rpc/documents/?disposition=published&ordering=-published_at&published_within_days=60 HTTP/1.0" 200 52
```