### PR TITLE
feat: make rev of RfcToBe editable

### DIFF
--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -64,7 +64,11 @@
         </DescriptionListItem>
         <DescriptionListItem term="Revision" :spacing="spacing">
           <DescriptionListDetails>
-            <span class="font-mono">{{ rfcToBe.draft?.rev ?? '(none)' }}</span>
+            <PatchRfcToBeField fieldName="rev" :is-read-only="props.isReadOnly"
+              :ui-mode="{ type: 'textbox', placeholder: 'e.g. 14', rows: 1, initialValue: rfcToBe.effectiveRev || undefined }"
+              :draft-name="rfcToBe.name ?? ''" :on-success="props.refresh">
+              <span class="font-mono">{{ rfcToBe.effectiveRev || '(none)' }}</span>
+            </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>
         <DescriptionListItem term="Pages" :spacing="spacing">

--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -65,9 +65,9 @@
         <DescriptionListItem term="Revision" :spacing="spacing">
           <DescriptionListDetails>
             <PatchRfcToBeField fieldName="rev" :is-read-only="props.isReadOnly"
-              :ui-mode="{ type: 'textbox', placeholder: 'e.g. 14', rows: 1, initialValue: rfcToBe.effectiveRev || undefined }"
+              :ui-mode="{ type: 'textbox', placeholder: 'e.g. 14', rows: 1, initialValue: rfcToBe.rev || undefined }"
               :draft-name="rfcToBe.name ?? ''" :on-success="props.refresh">
-              <span class="font-mono">{{ rfcToBe.effectiveRev || '(none)' }}</span>
+              <span class="font-mono">{{ rfcToBe.rev || '(none)' }}</span>
             </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5064,6 +5064,11 @@ components:
             ID. The DatatrackerPerson record will be created if it does not exist.
         is_april_first_rfc:
           type: boolean
+        rev:
+          type: string
+          description: Revision of draft being worked on. Overrides draft.rev when
+            set.
+          maxLength: 16
     PatchedRpcRelatedDocumentRequest:
       type: object
       description: Serializer for related document for an RfcToBe
@@ -5673,6 +5678,17 @@ components:
           readOnly: true
         is_april_first_rfc:
           type: boolean
+        rev:
+          type: string
+          description: Revision of draft being worked on. Overrides draft.rev when
+            set.
+          maxLength: 16
+        effective_rev:
+          type: string
+          nullable: true
+          description: The revision currently being worked on. Uses the RfcToBe's
+            rev if set, otherwise falls back to the datatracker draft rev.
+          readOnly: true
       required:
       - authors
       - boilerplate
@@ -5826,6 +5842,11 @@ components:
             ID. The DatatrackerPerson record will be created if it does not exist.
         is_april_first_rfc:
           type: boolean
+        rev:
+          type: string
+          description: Revision of draft being worked on. Overrides draft.rev when
+            set.
+          maxLength: 16
       required:
       - authors
       - boilerplate

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -4126,6 +4126,10 @@ components:
           minimum: 0
           nullable: true
           description: Page count
+        rev:
+          type: string
+          description: Revision of draft being worked on.
+          maxLength: 16
         keywords:
           type: string
           description: Comma-separated list of keywords
@@ -5066,8 +5070,7 @@ components:
           type: boolean
         rev:
           type: string
-          description: Revision of draft being worked on. Overrides draft.rev when
-            set.
+          description: Revision of draft being worked on.
           maxLength: 16
     PatchedRpcRelatedDocumentRequest:
       type: object
@@ -5685,8 +5688,7 @@ components:
           type: boolean
         rev:
           type: string
-          description: Revision of draft being worked on. Overrides draft.rev when
-            set.
+          description: Revision of draft being worked on.
           maxLength: 16
       required:
       - authors
@@ -5843,8 +5845,7 @@ components:
           type: boolean
         rev:
           type: string
-          description: Revision of draft being worked on. Overrides draft.rev when
-            set.
+          description: Revision of draft being worked on.
           maxLength: 16
       required:
       - authors

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5064,6 +5064,11 @@ components:
             ID. The DatatrackerPerson record will be created if it does not exist.
         is_april_first_rfc:
           type: boolean
+        rev:
+          type: string
+          description: Revision of draft being worked on. Overrides draft.rev when
+            set.
+          maxLength: 16
     PatchedRpcRelatedDocumentRequest:
       type: object
       description: Serializer for related document for an RfcToBe
@@ -5678,6 +5683,17 @@ components:
           readOnly: true
         is_april_first_rfc:
           type: boolean
+        rev:
+          type: string
+          description: Revision of draft being worked on. Overrides draft.rev when
+            set.
+          maxLength: 16
+        effective_rev:
+          type: string
+          nullable: true
+          description: The revision currently being worked on. Uses the RfcToBe's
+            rev if set, otherwise falls back to the datatracker draft rev.
+          readOnly: true
       required:
       - authors
       - boilerplate
@@ -5831,6 +5847,11 @@ components:
             ID. The DatatrackerPerson record will be created if it does not exist.
         is_april_first_rfc:
           type: boolean
+        rev:
+          type: string
+          description: Revision of draft being worked on. Overrides draft.rev when
+            set.
+          maxLength: 16
       required:
       - authors
       - boilerplate

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5688,12 +5688,6 @@ components:
           description: Revision of draft being worked on. Overrides draft.rev when
             set.
           maxLength: 16
-        effective_rev:
-          type: string
-          nullable: true
-          description: The revision currently being worked on. Uses the RfcToBe's
-            rev if set, otherwise falls back to the datatracker draft rev.
-          readOnly: true
       required:
       - authors
       - boilerplate

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5683,12 +5683,6 @@ components:
           description: Revision of draft being worked on. Overrides draft.rev when
             set.
           maxLength: 16
-        effective_rev:
-          type: string
-          nullable: true
-          description: The revision currently being worked on. Uses the RfcToBe's
-            rev if set, otherwise falls back to the datatracker draft rev.
-          readOnly: true
       required:
       - authors
       - boilerplate

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -505,6 +505,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
             "shepherd": shepherd.pk if shepherd is not None else None,
             "iesg_contact": iesg_contact.pk if iesg_contact is not None else None,
             "pages": draft.pages,
+            "rev": draft.rev,
             "consensus": draft_info.consensus,
         }
     )

--- a/rpc/migrations/0010_add_rfctobe_rev.py
+++ b/rpc/migrations/0010_add_rfctobe_rev.py
@@ -3,6 +3,14 @@
 from django.db import migrations, models
 
 
+def backfill_rev(apps, schema_editor):
+    RfcToBe = apps.get_model("rpc", "RfcToBe")
+    for rfctobe in RfcToBe.objects.filter(rev="", draft__isnull=False).select_related("draft"):
+        if rfctobe.draft.rev:
+            rfctobe.rev = rfctobe.draft.rev
+            rfctobe.save(update_fields=["rev"])
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("rpc", "0009_populate_rfctobe_published_formats"),
@@ -29,4 +37,5 @@ class Migration(migrations.Migration):
                 max_length=16,
             ),
         ),
+        migrations.RunPython(backfill_rev, migrations.RunPython.noop),
     ]

--- a/rpc/migrations/0010_add_rfctobe_rev.py
+++ b/rpc/migrations/0010_add_rfctobe_rev.py
@@ -5,7 +5,8 @@ from django.db import migrations, models
 
 def backfill_rev(apps, schema_editor):
     RfcToBe = apps.get_model("rpc", "RfcToBe")
-    for rfctobe in RfcToBe.objects.filter(rev="", draft__isnull=False).select_related("draft"):
+    qs = RfcToBe.objects.filter(rev="", draft__isnull=False).select_related("draft")
+    for rfctobe in qs:
         if rfctobe.draft.rev:
             rfctobe.rev = rfctobe.draft.rev
             rfctobe.save(update_fields=["rev"])

--- a/rpc/migrations/0010_add_rfctobe_rev.py
+++ b/rpc/migrations/0010_add_rfctobe_rev.py
@@ -1,0 +1,32 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rpc", "0009_populate_rfctobe_published_formats"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="historicalrfctobe",
+            name="rev",
+            field=models.CharField(
+                blank=True,
+                help_text="Revision of draft being worked on. Overrides draft.rev "
+                "when set.",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="rfctobe",
+            name="rev",
+            field=models.CharField(
+                blank=True,
+                help_text="Revision of draft being worked on. Overrides draft.rev "
+                "when set.",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/rpc/migrations/0010_add_rfctobe_rev.py
+++ b/rpc/migrations/0010_add_rfctobe_rev.py
@@ -7,7 +7,7 @@ def backfill_rev(apps, schema_editor):
     RfcToBe = apps.get_model("rpc", "RfcToBe")
     qs = RfcToBe.objects.filter(rev="", draft__isnull=False).select_related("draft")
     for rfctobe in qs:
-        if rfctobe.draft.rev:
+        if rfctobe.draft.rev:  # nothing to copy if draft also has no rev
             rfctobe.rev = rfctobe.draft.rev
             rfctobe.save(update_fields=["rev"])
 
@@ -23,8 +23,7 @@ class Migration(migrations.Migration):
             name="rev",
             field=models.CharField(
                 blank=True,
-                help_text="Revision of draft being worked on. Overrides draft.rev "
-                "when set.",
+                help_text="Revision of draft being worked on.",
                 max_length=16,
             ),
         ),
@@ -33,8 +32,7 @@ class Migration(migrations.Migration):
             name="rev",
             field=models.CharField(
                 blank=True,
-                help_text="Revision of draft being worked on. Overrides draft.rev "
-                "when set.",
+                help_text="Revision of draft being worked on.",
                 max_length=16,
             ),
         ),

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -224,6 +224,11 @@ class RfcToBe(models.Model):
         validators=[validate_not_unusable_rfc_number],
     )
 
+    rev = models.CharField(
+        max_length=16,
+        blank=True,
+        help_text="Revision of draft being worked on. Overrides draft.rev when set.",
+    )
     title = models.CharField(max_length=255, help_text="Document title")
     abstract = models.TextField(
         max_length=32000,

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -227,7 +227,7 @@ class RfcToBe(models.Model):
     rev = models.CharField(
         max_length=16,
         blank=True,
-        help_text="Revision of draft being worked on. Overrides draft.rev when set.",
+        help_text="Revision of draft being worked on.",
     )
     title = models.CharField(max_length=255, help_text="Document title")
     abstract = models.TextField(

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -767,6 +767,15 @@ class RfcToBeSerializer(serializers.ModelSerializer):
     )
     blocking_reasons = RfcToBeBlockingReasonSerializer(many=True, read_only=True)
     pub_owner = serializers.SerializerMethodField()
+    effective_rev = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.CharField(
+        allow_null=True,
+        help_text="The revision currently being worked on. Uses the RfcToBe's rev if "
+        "set, otherwise falls back to the datatracker draft rev.",
+    ))
+    def get_effective_rev(self, obj: RfcToBe) -> str | None:
+        return obj.rev or (obj.draft.rev if obj.draft else None)
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_pub_owner(self, obj: RfcToBe) -> str | None:
@@ -825,8 +834,10 @@ class RfcToBeSerializer(serializers.ModelSerializer):
             "stream_manager",
             "stream_manager_id",
             "is_april_first_rfc",
+            "rev",
+            "effective_rev",
         ]
-        read_only_fields = ["id", "draft", "published_at"]
+        read_only_fields = ["id", "draft", "published_at", "effective_rev"]
 
     def update(self, instance, validated_data):
         _UNSET = object()

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -848,12 +848,6 @@ class RfcToBeSerializer(serializers.ModelSerializer):
         _resolve_person_field("iesg_contact_id", "iesg_contact")
         return super().update(instance, validated_data)
 
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-        if not data.get("rev") and instance.draft:
-            data["rev"] = instance.draft.rev
-        return data
-
 
 def _person_label(pk) -> str:
     """Resolve a DatatrackerPerson pk to 'Name (#datatracker_id)'."""

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -767,15 +767,6 @@ class RfcToBeSerializer(serializers.ModelSerializer):
     )
     blocking_reasons = RfcToBeBlockingReasonSerializer(many=True, read_only=True)
     pub_owner = serializers.SerializerMethodField()
-    effective_rev = serializers.SerializerMethodField()
-
-    @extend_schema_field(serializers.CharField(
-        allow_null=True,
-        help_text="The revision currently being worked on. Uses the RfcToBe's rev if "
-        "set, otherwise falls back to the datatracker draft rev.",
-    ))
-    def get_effective_rev(self, obj: RfcToBe) -> str | None:
-        return obj.rev or (obj.draft.rev if obj.draft else None)
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_pub_owner(self, obj: RfcToBe) -> str | None:
@@ -835,9 +826,8 @@ class RfcToBeSerializer(serializers.ModelSerializer):
             "stream_manager_id",
             "is_april_first_rfc",
             "rev",
-            "effective_rev",
         ]
-        read_only_fields = ["id", "draft", "published_at", "effective_rev"]
+        read_only_fields = ["id", "draft", "published_at"]
 
     def update(self, instance, validated_data):
         _UNSET = object()
@@ -857,6 +847,12 @@ class RfcToBeSerializer(serializers.ModelSerializer):
         _resolve_person_field("shepherd_id", "shepherd")
         _resolve_person_field("iesg_contact_id", "iesg_contact")
         return super().update(instance, validated_data)
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if not data.get("rev") and instance.draft:
+            data["rev"] = instance.draft.rev
+        return data
 
 
 def _person_label(pk) -> str:

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1182,6 +1182,7 @@ class CreateRfcToBeSerializer(serializers.ModelSerializer):
             "shepherd",
             "iesg_contact",
             "pages",
+            "rev",
             "keywords",
             "iana_status_slug",
             "consensus",

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -239,6 +239,21 @@ def refresh_rfc_index_task():
 
 
 @shared_task
+def backfill_rev_task():
+    """One-time task: copy draft.rev into rfctobe.rev for records where it is blank."""
+    qs = RfcToBe.objects.filter(rev="", draft__isnull=False).select_related("draft")
+    count = 0
+    for rfctobe in qs:
+        rev = rfctobe.draft.rev
+        if rev:
+            rfctobe.rev = rev
+            rfctobe.save(update_fields=["rev"])
+            count += 1
+    logger.info("backfill_rev_task: updated %d record(s)", count)
+    return count
+
+
+@shared_task
 def update_blocked_assignments_for_in_progress_rfcs_task():
     """Process all in_progress RfcToBe instances to apply blocked assignments"""
     for rfc in RfcToBe.objects.filter(disposition_id="in_progress"):

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -239,21 +239,6 @@ def refresh_rfc_index_task():
 
 
 @shared_task
-def backfill_rev_task():
-    """One-time task: copy draft.rev into rfctobe.rev for records where it is blank."""
-    qs = RfcToBe.objects.filter(rev="", draft__isnull=False).select_related("draft")
-    count = 0
-    for rfctobe in qs:
-        rev = rfctobe.draft.rev
-        if rev:
-            rfctobe.rev = rev
-            rfctobe.save(update_fields=["rev"])
-            count += 1
-    logger.info("backfill_rev_task: updated %d record(s)", count)
-    return count
-
-
-@shared_task
 def update_blocked_assignments_for_in_progress_rfcs_task():
     """Process all in_progress RfcToBe instances to apply blocked assignments"""
     for rfc in RfcToBe.objects.filter(disposition_id="in_progress"):


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1327

add new field `RfcToBe.rev`. If set, it will overwrite the draft's original value `draft.rev`
when writing, only update `RfcToBe.rev`, never touch `draft.rev`