### PR TITLE
fix: improve author name extraction for metadata sync

### DIFF
--- a/rpc/lifecycle/metadata.py
+++ b/rpc/lifecycle/metadata.py
@@ -291,7 +291,10 @@ class Metadata:
     def extract_name_from_author_dict(author_dict) -> str:
         """Extract name from an author_dict
 
-        Extracts the name as it should appear in the titlepage block of the RFC.
+        Extracts the name, formatted as for titlepage_name in datatracker. This should
+        match the Latinized form of the name in initials + surname format for now.
+        It's likely this will eventually change to capture non-Latin names, but we're
+        not doing that yet.
         """
         xml_name = (
             author_dict.get("initials", "").rstrip()

--- a/rpc/lifecycle/metadata.py
+++ b/rpc/lifecycle/metadata.py
@@ -293,7 +293,9 @@ class Metadata:
         Extracts the name as it should appear in the titlepage block of the RFC.
         """
         xml_name = (
-            author_dict.get("initials", "") + " " + author_dict.get("surname", "")
+            author_dict.get("initials", "").rstrip()
+            + " "
+            + author_dict.get("surname", "").lstrip()
         ).strip()
         if not xml_name:
             xml_fullname = (

--- a/rpc/lifecycle/metadata.py
+++ b/rpc/lifecycle/metadata.py
@@ -6,7 +6,6 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 from itertools import zip_longest
-from typing import Any
 
 from django.db import transaction
 
@@ -96,8 +95,8 @@ class Metadata:
             "subseries": subseries,
         }
 
-    @staticmethod
-    def update_metadata(rfctobe, metadata):
+    @classmethod
+    def update_metadata(cls, rfctobe, metadata):
         """Update metadata fields from metadata dictionary
 
         First compares all fields to see what needs to be updated,
@@ -200,11 +199,7 @@ class Metadata:
                                 )
 
                             # Verify names match
-                            xml_name = (
-                                xml_author.get("initials", "")
-                                + " "
-                                + xml_author.get("surname", "")
-                            ).strip()
+                            xml_name = cls.extract_name_from_author_dict(xml_author)
                             db_name = db_author.titlepage_name
                             if xml_name != db_name:
                                 raise ValueError(

--- a/rpc/lifecycle/metadata.py
+++ b/rpc/lifecycle/metadata.py
@@ -6,6 +6,7 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 from itertools import zip_longest
+from typing import Any
 
 from django.db import transaction
 
@@ -290,6 +291,29 @@ class Metadata:
 
         return updated_fields
 
+    @staticmethod
+    def extract_name_from_author_dict(author_dict) -> str:
+        """Extract name from an author_dict
+
+        Extracts the name as it should appear in the titlepage block of the RFC.
+        """
+        xml_name = (
+            author_dict.get("initials", "") + " " + author_dict.get("surname", "")
+        ).strip()
+        if not xml_name:
+            xml_fullname = (
+                author_dict.get("asciiFullname", "") or author_dict.get("fullname", "")
+            ).strip()
+            # Convert full name to initials format
+            name_parts = xml_fullname.split()
+            if len(name_parts) > 1:
+                # Convert all parts except last to initials, keep surname as-is
+                initials = [p[0] + "." for p in name_parts[:-1]]
+                xml_name = " ".join(initials + [name_parts[-1]])
+            else:
+                xml_name = xml_fullname
+        return xml_name
+
 
 class MetadataComparator:
     """Compare XML metadata with RfcToBe database values"""
@@ -442,22 +466,7 @@ class MetadataComparator:
                 continue
 
             # Extract author names
-            xml_name = (
-                xml_author.get("initials", "") + " " + xml_author.get("surname", "")
-            ).strip()
-            if not xml_name:
-                xml_fullname = (
-                    xml_author.get("asciiFullname", "")
-                    or xml_author.get("fullname", "")
-                ).strip()
-                # Convert full name to initials format
-                name_parts = xml_fullname.split()
-                if len(name_parts) > 1:
-                    # Convert all parts except last to initials, keep surname as-is
-                    initials = [p[0] + "." for p in name_parts[:-1]]
-                    xml_name = " ".join(initials + [name_parts[-1]])
-                else:
-                    xml_name = xml_fullname
+            xml_name = Metadata.extract_name_from_author_dict(xml_author)
             db_name = db_author.titlepage_name
 
             # Check if names match

--- a/rpc/lifecycle/metadata.py
+++ b/rpc/lifecycle/metadata.py
@@ -6,6 +6,7 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 from itertools import zip_longest
+from typing import Any
 
 from django.db import transaction
 
@@ -451,7 +452,7 @@ class MetadataComparator:
         for position, (xml_author, db_author) in enumerate(
             zip_longest(xml_value, db_authors, fillvalue=None)
         ):
-            item = {"position": position}
+            item: dict[str, Any] = {"position": position}
 
             if xml_author is None or db_author is None:
                 # Mismatched lengths - cannot fix

--- a/rpc/lifecycle/tests_metadata.py
+++ b/rpc/lifecycle/tests_metadata.py
@@ -10,20 +10,20 @@ class MetadataTests(TestCase):
             Metadata.extract_name_from_author_dict({}), "", "empty input dict"
         )
         self.assertEqual(
-            Metadata.extract_name_from_author_dict({"initials": " A. B. "}),
-            "A. B.",
+            Metadata.extract_name_from_author_dict({"initials": " Ä. B. "}),
+            "Ä. B.",
             "initials only plus stripping",
         )
         self.assertEqual(
-            Metadata.extract_name_from_author_dict({"surname": " Clyde "}),
-            "Clyde",
+            Metadata.extract_name_from_author_dict({"surname": " Cly∂e "}),
+            "Cly∂e",
             "surname only plus stripping",
         )
         self.assertEqual(
             Metadata.extract_name_from_author_dict(
-                {"initials": " A. B. ", "surname": " Clyde"}
+                {"initials": " À. B. ", "surname": " Clydé"}
             ),
-            "A. B. Clyde",
+            "À. B. Clydé",
             "initials+surname + stripping",
         )
         self.assertEqual(
@@ -53,8 +53,8 @@ class MetadataTests(TestCase):
             "asciiFullname has priority + single name",
         )
         self.assertEqual(
-            Metadata.extract_name_from_author_dict({"fullname": "Diane Egawa"}),
-            "D. Egawa",
+            Metadata.extract_name_from_author_dict({"fullname": "∂iane Egawa"}),
+            "∂. Egawa",
             "fullname with two names",
         )
         self.assertEqual(

--- a/rpc/lifecycle/tests_metadata.py
+++ b/rpc/lifecycle/tests_metadata.py
@@ -1,0 +1,69 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+from django.test import TestCase
+
+from .metadata import Metadata
+
+
+class MetadataTests(TestCase):
+    def test_extract_name_from_author_dict(self):
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict({}), "", "empty input dict"
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict({"initials": " A. B. "}),
+            "A. B.",
+            "initials only plus stripping",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict({"surname": " Clyde "}),
+            "Clyde",
+            "surname only plus stripping",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict(
+                {"initials": " A. B. ", "surname": " Clyde"}
+            ),
+            "A. B. Clyde",
+            "initials+surname + stripping",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict(
+                {
+                    "initials": "A. B.",
+                    "surname": "Clyde",
+                    "fullname": "Diane Egawa",
+                    "asciiFullname": "Frank Gouda",
+                }
+            ),
+            "A. B. Clyde",
+            "initials+surname have priority",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict(
+                {"fullname": "Diane Egawa", "asciiFullname": "Frank Gouda"}
+            ),
+            "F. Gouda",
+            "asciiFullname has priority",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict(
+                {"fullname": "Diane Egawa", "asciiFullname": "Gouda"}
+            ),
+            "Gouda",
+            "asciiFullname has priority + single name",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict({"fullname": "Diane Egawa"}),
+            "D. Egawa",
+            "fullname with two names",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict({"fullname": "Egawa"}),
+            "Egawa",
+            "fullname with one name",
+        )
+        self.assertEqual(
+            Metadata.extract_name_from_author_dict({"fullname": "江川"}),
+            "江川",
+            "fullname with one name",
+        )


### PR DESCRIPTION
Author name extraction code had diverged between the `MetadataComparator` comparison and the metadata sync. This extracts the comparator's code and uses it in both contexts.

Tests the extracted method but does not tackle testing the comparator or sync code. That should be done as a separate project.

Fixes #1368 (I believe)