### PR TITLE
feat: allow display of withdrawn docs

### DIFF
--- a/client/app/components/HeaderNav.vue
+++ b/client/app/components/HeaderNav.vue
@@ -28,7 +28,7 @@
               <button
                 type="button"
                 class="flex w-full items-baseline gap-2 px-4 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-neutral-700"
-                @mousedown.prevent="navigateTo(`/docs/${doc.name}`); navSearch = ''; showResults = false"
+                @mousedown.prevent="navigateTo(`/docs/${doc.disposition === 'withdrawn' ? doc.id : doc.name}`); navSearch = ''; showResults = false"
               >
                 <span class="font-semibold text-gray-900 dark:text-neutral-100">{{ doc.name }}</span>
                 <span v-if="doc.rfcNumber" class="text-xs text-gray-500 dark:text-neutral-400">RFC {{ doc.rfcNumber }}</span>

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -166,12 +166,15 @@ PUB_QUEUE_API_KEY_ENDPOINT = "api.pubq"
 
 
 def resolve_rfctobe(identifier: str) -> RfcToBe:
-    """Return the preferred RfcToBe for a given draft name.
+    """Return the RfcToBe for a given identifier.
 
-    If identifier looks like 'rfc1234', look up by rfc_number instead.
-    When multiple RfcToBes share a draft name (e.g., one withdrawn and one
-    in-progress), the non-withdrawn one is preferred.
+    Identifiers are resolved in order:
+    - Numeric string → direct lookup by RfcToBe.pk (allows linking withdrawn records)
+    - 'rfc1234' → lookup by rfc_number; non-withdrawn preferred
+    - Draft name → lookup by draft name; non-withdrawn preferred
     """
+    if identifier.isdigit():
+        return get_object_or_404(RfcToBe, pk=int(identifier))
     if identifier.lower().startswith("rfc") and identifier[3:].strip().isdigit():
         rfc_number = int(identifier[3:].strip())
         qs = RfcToBe.objects.filter(rfc_number=rfc_number)


### PR DESCRIPTION
resolves https://github.com/ietf-tools/purple/issues/1363

for withdrawn docs in search results, we use link like `{purple}/docs/{rfcToBeId}` instead of `{purple}/docs/{draftName}`

while `{purple}/docs/{draftName}` defaults to a not-withdrawn doc if multiple exist, the new intentifier `{purple}/docs/{rfcToBeId}` will return the doc of that ID no matter what