### PR TITLE
feat: improve team member page; group and order assignments by role

### DIFF
--- a/client/app/pages/team/[id].vue
+++ b/client/app/pages/team/[id].vue
@@ -45,208 +45,151 @@
               </span>
             </h1>
           </div>
-          <div class="flex items-center gap-x-4 sm:gap-x-6">
-            <HeadlessMenu as="div" class="relative sm:hidden">
-              <HeadlessMenuButton class="-m-3 block p-3">
-                <span class="sr-only">More</span>
-                <Icon name="uil:bars" class="h-5 w-5 text-gray-500" aria-hidden="true" />
-              </HeadlessMenuButton>
+          <HeadlessMenu as="div" class="relative sm:hidden">
+            <HeadlessMenuButton class="-m-3 block p-3">
+              <span class="sr-only">More</span>
+              <Icon name="uil:bars" class="h-5 w-5 text-gray-500" aria-hidden="true" />
+            </HeadlessMenuButton>
 
-              <transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95">
-                <HeadlessMenuItems
-                  class="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
-                  <HeadlessMenuItem v-slot="{ active }">
-                    <button
-                      type="button"
-                      :class="[
-                        active ? 'bg-gray-50' : '',
-                        'block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900'
-                      ]">
-                      Copy URL
-                    </button>
-                  </HeadlessMenuItem>
-                  <HeadlessMenuItem v-slot="{ active }">
-                    <a
-                      href="#"
-                      :class="[
-                        active ? 'bg-gray-50' : '',
-                        'block px-3 py-1 text-sm leading-6 text-gray-900'
-                      ]"
-                      >Edit</a
-                    >
-                  </HeadlessMenuItem>
-                </HeadlessMenuItems>
-              </transition>
-            </HeadlessMenu>
-          </div>
+            <transition
+              enter-active-class="transition ease-out duration-100"
+              enter-from-class="transform opacity-0 scale-95"
+              enter-to-class="transform opacity-100 scale-100"
+              leave-active-class="transition ease-in duration-75"
+              leave-from-class="transform opacity-100 scale-100"
+              leave-to-class="transform opacity-0 scale-95">
+              <HeadlessMenuItems
+                class="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
+                <HeadlessMenuItem v-slot="{ active }">
+                  <button
+                    type="button"
+                    :class="[
+                      active ? 'bg-gray-50' : '',
+                      'block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900'
+                    ]">
+                    Copy URL
+                  </button>
+                </HeadlessMenuItem>
+                <HeadlessMenuItem v-slot="{ active }">
+                  <a
+                    href="#"
+                    :class="[
+                      active ? 'bg-gray-50' : '',
+                      'block px-3 py-1 text-sm leading-6 text-gray-900'
+                    ]"
+                    >Edit</a
+                  >
+                </HeadlessMenuItem>
+              </HeadlessMenuItems>
+            </transition>
+          </HeadlessMenu>
         </div>
       </div>
     </header>
 
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <div
-        class="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-        <!-- Invoice summary -->
-        <div class="lg:col-start-3 lg:row-end-1">
-          <h2 class="sr-only">Summary</h2>
-
-          <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5">
-            <dl class="flex flex-col">
-              <div class="flex-auto pl-6 pt-6">
-                <dt class="text-sm font-semibold leading-6 text-gray-900">Workload</dt>
-                <dd class="mt-1 text-sm leading-6 text-gray-900">
-                  <WorkloadSummary v-if="personWorkload" :workload="personWorkload" mode="rows" />
-                  <Icon v-else name="ei:spinner-3" size="0.8em" class="animate-spin" />
-                </dd>
-              </div>
-              <div class="flex-none px-6 pt-4">
-                <dt>Status</dt>
-                <dd v-if="person">
-                  <span
-                    :class="[
-                      person?.isActive === true
-                        ? 'bg-green-50 text-green-600 ring-green-600/20'
-                        : 'bg-red-50 text-red-600 ring-red-600/20',
-                      'rounded-md px-2 py-1 text-xs ring-1 ring-inset'
-                    ]">
-                    <template v-if="person.isActive">active</template>
-                    <template v-else>inactive</template>
-                  </span>
-                </dd>
-              </div>
-              <div class="px-6 pt-4">
-                <dt>Roles</dt>
-                <dd class="mt-1 text-sm leading-6">
-                  <template v-if="personStatus === 'pending'">
-                    <Icon name="ei:spinner-3" size="0.8em" class="animate-spin" />
-                  </template>
-                  <template v-if="personStatus === 'success'">
-                    {{
-                      person?.roles && person.roles.length > 0
-                        ? person.roles.map((role) => role.name).join(', ')
-                        : 'No roles assigned'
-                    }}
-                  </template>
-                </dd>
-              </div>
-            </dl>
+      <!-- Summary bar -->
+      <div class="mb-6 rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5">
+        <dl class="flex flex-wrap divide-x divide-gray-900/5 dark:divide-white/10">
+          <div class="px-6 py-4">
+            <dt class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-200">
+              Workload
+            </dt>
+            <dd class="mt-1 text-sm leading-6 text-gray-900 dark:text-neutral-300">
+              <WorkloadSummary v-if="personWorkload" :workload="personWorkload" mode="rows" />
+              <Icon v-else name="ei:spinner-3" size="0.8em" class="animate-spin" />
+            </dd>
           </div>
-        </div>
-        <div class="lg:col-start-3 lg:row-end-2">
-          <!-- Activity feed -->
-          <h2 class="text-sm font-semibold leading-6 text-gray-900">Activity (mocked)</h2>
-          <ul role="list" class="mt-6 space-y-6">
-            <li
-              v-for="(activityItem, activityItemIdx) in activity"
-              :key="activityItem.id"
-              class="relative flex gap-x-4">
-              <div
+          <div class="px-6 py-4">
+            <dt class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-200">
+              Status
+            </dt>
+            <dd class="mt-1" v-if="person">
+              <span
                 :class="[
-                  activityItemIdx === activity.length - 1 ? 'h-6' : '-bottom-6',
-                  'absolute left-0 top-0 flex w-6 justify-center'
+                  person?.isActive === true
+                    ? 'bg-green-50 text-green-600 ring-green-600/20'
+                    : 'bg-red-50 text-red-600 ring-red-600/20',
+                  'rounded-md px-2 py-1 text-xs ring-1 ring-inset'
                 ]">
-                <div class="w-px bg-gray-200" />
-              </div>
-              <div class="relative flex h-6 w-6 flex-none items-center justify-center bg-grey-50">
-                <Icon
-                  v-if="activityItem.type === 'paid'"
-                  name="uil:times"
-                  class="h-6 w-6 text-indigo-600"
-                  aria-hidden="true" />
-                <div v-else class="h-1.5 w-1.5 rounded-full bg-gray-100 ring-1 ring-gray-300" />
-              </div>
-              <p class="flex-auto py-0.5 text-xs leading-5 text-gray-500">
-                <span class="font-medium text-gray-900">{{ person?.name }}</span>
-                {{ activityItem.type }}
-                the document.
-              </p>
-              <time
-                :datetime="activityItem.dateTime"
-                class="flex-none py-0.5 text-xs leading-5 text-gray-500">
-                {{ activityItem.date }}
-              </time>
-            </li>
-          </ul>
-        </div>
-        <!-- Assignments List -->
-        <div class="lg:col-span-2 lg:row-span-2">
-          <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5 p-6">
-            <h2 class="text-sm font-semibold leading-6 text-gray-900">Active Assignments</h2>
-
-            <template v-if="assignmentsStatus === 'error'">
-              {{ assignmentsError }}
-              (note: this might be a permissions error)
-            </template>
-
-            <template v-if="assignmentsStatus === 'pending'">
-              <Icon name="ei:spinner-3" size="1em" class="animate-spin" />
-            </template>
-
-            <template v-if="assignmentsStatus === 'success'">
-              <div v-if="assignments && assignments.length > 0" class="mt-6">
-                <div class="space-y-4">
-                  <div
-                    v-for="assignment in assignments"
-                    :key="assignment.id"
-                    class="border border-gray-200 rounded-lg p-4 bg-gray-50">
-                    <div class="flex items-start justify-between">
-                      <div class="flex-1">
-                        <h3 class="text-sm font-semibold text-gray-900">
-                          <Anchor
-                            :href="`/docs/${assignment.rfcToBe?.draft?.name ?? ''}`"
-                            class="text-violet-700 dark:text-violet-300 hover:text-violet-600 hover:bg-gray-50 hover:underline focus:underline dark:hover:bg-violet-800">
-                            {{ assignment.rfcToBe?.draft?.name }}
-                          </Anchor>
-                        </h3>
-                        <div
-                          v-if="
-                            assignment.role === 'blocked' &&
-                            assignment.rfcToBe?.blockingReasons?.length
-                          "
-                          class="ml-2 mt-0.5 text-xs text-gray-500 dark:text-neutral-400">
-                          <span class="font-medium">Reasons:</span>
-                          <ul class="list-disc list-inside">
-                            <li
-                              v-for="br in assignment.rfcToBe.blockingReasons"
-                              :key="br.reason?.slug">
-                              {{ br.reason?.name }}
-                            </li>
-                          </ul>
-                        </div>
-                        <span v-else-if="assignment.comment">
-                          {{ assignment.comment }}
-                        </span>
-                        <div class="mt-2 flex items-center gap-4 text-xs text-gray-500">
-                          <span> Time spent: {{ assignment.timeSpent }} </span>
-                          <span
-                            v-if="assignment.state"
-                            :class="[
-                              assignment.state === 'done'
-                                ? 'text-green-600'
-                                : assignment.state === 'in_progress'
-                                  ? 'text-blue-600'
-                                  : 'text-yellow-600'
-                            ]">
-                            {{ assignment.role }} ({{ assignment.state }})
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div v-else class="mt-6 text-center py-8">
-                <!-- No assignments message -->
-                <p class="text-sm text-gray-500">No current assignments</p>
-              </div>
-            </template>
+                <template v-if="person.isActive">active</template>
+                <template v-else>inactive</template>
+              </span>
+            </dd>
           </div>
+          <div class="px-6 py-4">
+            <dt class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-200">
+              Roles
+            </dt>
+            <dd class="mt-1 text-sm leading-6 text-gray-600 dark:text-neutral-400">
+              <template v-if="personStatus === 'pending'">
+                <Icon name="ei:spinner-3" size="0.8em" class="animate-spin" />
+              </template>
+              <template v-if="personStatus === 'success'">
+                {{
+                  person?.roles && person.roles.length > 0
+                    ? person.roles.map((role) => role.name).join(', ')
+                    : 'No roles assigned'
+                }}
+              </template>
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <!-- Assignments List -->
+      <div>
+        <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5 p-6">
+          <h2 class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-200">
+            Active Assignments
+          </h2>
+
+          <template v-if="assignmentsStatus === 'error'">
+            {{ assignmentsError }}
+            (note: this might be a permissions error)
+          </template>
+
+          <template v-if="assignmentsStatus === 'pending'">
+            <Icon name="ei:spinner-3" size="1em" class="animate-spin" />
+          </template>
+
+          <template v-if="assignmentsStatus === 'success'">
+            <div v-if="sortedAssignments.length > 0" class="mt-4">
+              <RpcTable>
+                <RpcThead>
+                  <tr
+                    v-for="headerGroup in assignmentsTable.getHeaderGroups()"
+                    :key="headerGroup.id">
+                    <RpcTh
+                      v-for="header in headerGroup.headers"
+                      :key="header.id"
+                      :colSpan="header.colSpan"
+                      :is-sortable="header.column.getCanSort()"
+                      :sort-direction="header.column.getIsSorted()"
+                      :column-name="getVNodeText(header.column.columnDef.header)"
+                      @click="header.column.getToggleSortingHandler()?.($event)">
+                      <div class="flex items-center gap-2">
+                        <FlexRender
+                          v-if="!header.isPlaceholder"
+                          :render="header.column.columnDef.header"
+                          :props="header.getContext()" />
+                      </div>
+                    </RpcTh>
+                  </tr>
+                </RpcThead>
+                <RpcTbody>
+                  <tr v-for="row in assignmentsTable.getRowModel().rows" :key="row.id">
+                    <RpcTd v-for="cell in row.getVisibleCells()" :key="cell.id">
+                      <FlexRender :render="cell.column.columnDef.cell" :props="cell.getContext()" />
+                    </RpcTd>
+                  </tr>
+                </RpcTbody>
+              </RpcTable>
+            </div>
+            <div v-else class="mt-6 text-center py-8">
+              <p class="text-sm text-gray-500">No current assignments</p>
+            </div>
+          </template>
         </div>
       </div>
     </div>
@@ -254,7 +197,20 @@
 </template>
 
 <script setup lang="ts">
-import type { Cluster } from '~/purple_client'
+import { Anchor, Icon, RpcLabel } from '#components'
+import {
+  FlexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useVueTable,
+  createColumnHelper
+} from '@tanstack/vue-table'
+import type { SortingState } from '@tanstack/vue-table'
+import { useLocalStorage } from '@vueuse/core'
+import { DateTime } from 'luxon'
+import type { Cluster, Label, NestedAssignment } from '~/purple_client'
+import { calculateEnqueuedAtData, renderEnqueuedAt } from '~/utils/queue'
+import { ANCHOR_STYLE } from '~/utils/html'
 
 const route = useRoute()
 const api = useApi()
@@ -301,6 +257,239 @@ const {
   default: () => [] as Cluster[]
 })
 
+const { data: allLabels } = await useAsyncData('labels', () => api.labelsList(), {
+  server: false,
+  lazy: true,
+  default: () => [] as Label[]
+})
+
+const ROLES = [
+  { slug: 'enqueuer', label: 'Enqueuer' },
+  { slug: 'ref_checker', label: 'Ref Checker' },
+  { slug: 'formatting', label: 'Formatting' },
+  { slug: 'first_editor', label: 'First Edit' },
+  { slug: 'second_editor', label: 'Second Edit' },
+  { slug: 'final_review_editor', label: 'Final Review' },
+  { slug: 'publisher', label: 'Publisher' }
+]
+
+const roleLabel = (slug: string) => ROLES.find((r) => r.slug === slug)?.label ?? slug
+const roleOrder = (slug: string) => ROLES.findIndex((r) => r.slug === slug)
+
+// For a blocked assignment, find its current workflow stage from the document's
+// pending activities
+const blockedStage = (a: NestedAssignment): { slug: string; index: number } | null =>
+  (a.rfcToBe?.pendingActivities ?? []).reduce<{ slug: string; index: number } | null>(
+    (best, activity) => {
+      const index = roleOrder(activity.slug)
+      if (index === -1) return best
+      return best === null || index < best.index ? { slug: activity.slug, index } : best
+    },
+    null
+  )
+
+const sortedAssignments = computed(() => {
+  if (!assignments.value) return []
+
+  const order = (a: (typeof assignments.value)[number]): number => {
+    if (a.role === 'blocked') {
+      // Sort immediately after the inferred stage, or to the very end if unknown.
+      const stage = blockedStage(a)
+      return stage ? stage.index + 0.5 : ROLES.length + 1
+    }
+    const idx = roleOrder(a.role)
+    return idx === -1 ? ROLES.length : idx
+  }
+
+  return [...assignments.value].sort((a, b) => {
+    const roleDiff = order(a) - order(b)
+    if (roleDiff !== 0) return roleDiff
+    // Within the same role, newest enqueue date first
+    const aTime = a.enqueuedAt?.getTime() ?? -Infinity
+    const bTime = b.enqueuedAt?.getTime() ?? -Infinity
+    return bTime - aTime
+  })
+})
+
+const assignmentColumnHelper = createColumnHelper<NestedAssignment>()
+const assignmentSorting = useLocalStorage<SortingState>('team-member-assignments-sorting', [])
+
+const assignmentDisplayRole = (a: NestedAssignment): string => {
+  if (a.role !== 'blocked') return a.role
+  return blockedStage(a)?.slug ?? 'blocked'
+}
+
+const assignmentColumns = [
+  assignmentColumnHelper.accessor((a) => a.rfcToBe?.rfcNumber ?? null, {
+    id: 'rfcNumber',
+    header: 'RFC',
+    cell: (data) => {
+      const num = data.getValue()
+      return num ? h('span', { class: 'font-mono' }, `RFC ${num}`) : ''
+    },
+    sortingFn: 'alphanumeric',
+    sortUndefined: 'last'
+  }),
+  assignmentColumnHelper.display({
+    id: 'document',
+    header: 'Document',
+    cell: ({ row }) => {
+      const a = row.original
+      const name = a.rfcToBe?.draft?.name ?? ''
+      const linkNode = h(Anchor, { href: `/docs/${name}`, class: ANCHOR_STYLE }, () => name)
+      const blockingReasons = a.role === 'blocked' ? (a.rfcToBe?.blockingReasons ?? []) : []
+      return h('div', [
+        linkNode,
+        blockingReasons.length
+          ? h(
+              'ul',
+              { class: 'mt-0.5 list-disc list-inside text-xs text-red-500 dark:text-red-400' },
+              blockingReasons.map((br) => h('li', br.reason?.name))
+            )
+          : null,
+        a.comment
+          ? h(
+              'blockquote',
+              {
+                class:
+                  'mt-1 border-l-2 border-gray-300 dark:border-neutral-600 pl-2 text-xs italic text-gray-500 dark:text-neutral-400'
+              },
+              a.comment
+            )
+          : null
+      ])
+    },
+    enableSorting: false
+  }),
+  assignmentColumnHelper.display({
+    id: 'labels',
+    header: 'Labels',
+    cell: ({ row }) => {
+      const ids = row.original.rfcToBe?.labels ?? []
+      if (!ids.length) return ''
+      const resolved = ids
+        .map((id) => allLabels.value.find((l) => l.id === id))
+        .filter(Boolean) as Label[]
+      if (!resolved.length) return ''
+      return h(
+        'span',
+        { class: 'flex flex-wrap gap-1' },
+        resolved.map((l) => h(RpcLabel, { label: l }))
+      )
+    },
+    enableSorting: false
+  }),
+  assignmentColumnHelper.accessor('role', {
+    header: 'Role',
+    cell: ({ row }) => {
+      const a = row.original
+      const displayRole = assignmentDisplayRole(a)
+      const label = roleLabel(displayRole)
+      const isBlocked = a.role === 'blocked'
+      return h(
+        'span',
+        { class: isBlocked ? 'text-red-600 dark:text-red-400' : '' },
+        isBlocked ? `${label} (blocked)` : label
+      )
+    },
+    sortingFn: (rowA, rowB) => {
+      const orderA = roleOrder(assignmentDisplayRole(rowA.original))
+      const orderB = roleOrder(assignmentDisplayRole(rowB.original))
+      return orderA - orderB
+    }
+  }),
+  assignmentColumnHelper.accessor('enqueuedAt', {
+    header: () =>
+      h('div', { class: 'text-center' }, [
+        h('div', 'Enqueue Date'),
+        h('div', { class: 'text-xs' }, '(Weeks in queue)')
+      ]),
+    cell: (data) => {
+      const value = data.getValue()
+      if (!value) return ''
+      return renderEnqueuedAt(calculateEnqueuedAtData(value))
+    },
+    sortingFn: (rowA, rowB, columnId) => {
+      const a = rowA.getValue<Date | null | undefined>(columnId)
+      const b = rowB.getValue<Date | null | undefined>(columnId)
+      const aTime = a instanceof Date ? a.getTime() : -Infinity
+      const bTime = b instanceof Date ? b.getTime() : -Infinity
+      return aTime - bTime
+    }
+  }),
+  assignmentColumnHelper.accessor('assignedAt', {
+    header: 'Assigned Date',
+    cell: (data) => {
+      const value = data.getValue()
+      if (!value) return ''
+      return h(
+        'time',
+        { datetime: value.toISOString(), class: 'text-xs' },
+        DateTime.fromJSDate(value).toISODate() ?? ''
+      )
+    },
+    sortingFn: (rowA, rowB, columnId) => {
+      const a = rowA.getValue<Date | null | undefined>(columnId)
+      const b = rowB.getValue<Date | null | undefined>(columnId)
+      const aTime = a instanceof Date ? a.getTime() : -Infinity
+      const bTime = b instanceof Date ? b.getTime() : -Infinity
+      return aTime - bTime
+    },
+    sortUndefined: 'last'
+  }),
+  assignmentColumnHelper.accessor('state', {
+    header: 'Status',
+    cell: (data) => {
+      const v = data.getValue()
+      if (!v) return ''
+      const cls =
+        v === 'done' ? 'text-green-600' : v === 'in_progress' ? 'text-blue-600' : 'text-yellow-600'
+      return h('span', { class: cls }, v)
+    },
+    sortingFn: 'alphanumeric'
+  }),
+  assignmentColumnHelper.accessor((a) => a.rfcToBe?.cluster?.number ?? null, {
+    id: 'cluster',
+    header: 'Cluster',
+    cell: ({ row }) => {
+      const num = row.original.rfcToBe?.cluster?.number
+      if (!num) return ''
+      return h(Anchor, { href: `/clusters/${num}`, class: ANCHOR_STYLE }, () => [
+        h(Icon, { name: 'pajamas:group', class: 'h-4 w-4 inline-block mr-1' }),
+        String(num)
+      ])
+    },
+    sortingFn: 'alphanumeric',
+    sortUndefined: 'last'
+  }),
+  assignmentColumnHelper.accessor((a) => a.rfcToBe?.draft?.pages ?? null, {
+    id: 'pages',
+    header: 'Pages',
+    cell: (data) => data.getValue() ?? '-',
+    sortingFn: 'alphanumeric',
+    sortUndefined: 'last'
+  })
+]
+
+const assignmentsTable = useVueTable({
+  get data() {
+    return sortedAssignments.value
+  },
+  columns: assignmentColumns,
+  state: {
+    get sorting() {
+      return assignmentSorting.value
+    }
+  },
+  onSortingChange: (updater) => {
+    assignmentSorting.value =
+      typeof updater === 'function' ? updater(assignmentSorting.value) : updater
+  },
+  getCoreRowModel: getCoreRowModel(),
+  getSortedRowModel: getSortedRowModel(),
+  manualSorting: false
+})
+
 // Handle error state
 if (personError.value) {
   throw createError({
@@ -321,30 +510,6 @@ const personWorkload = computed((): RpcPeopleWorkload[number] | undefined => {
     .filter((maybeDoc) => !!maybeDoc)
   return calculatePeopleWorkload(clusters.value, docs)[personId]
 })
-
-const activity = [
-  {
-    id: 1,
-    type: 'created',
-    person: { name: 'Chelsea Hagon' },
-    date: '7d ago',
-    dateTime: '2023-01-23T10:32'
-  },
-  {
-    id: 2,
-    type: 'edited',
-    person: { name: 'Chelsea Hagon' },
-    date: '6d ago',
-    dateTime: '2023-01-23T11:03'
-  },
-  {
-    id: 3,
-    type: 'published',
-    person: { name: 'Chelsea Hagon' },
-    date: '6d ago',
-    dateTime: '2023-01-23T11:24'
-  }
-]
 
 useHead(() => ({
   title: person.value ? person.value.name : 'Loading...'

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -4732,6 +4732,16 @@ components:
           type: string
         time_spent:
           type: string
+        enqueued_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        assigned_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
       required:
         - role
     PaginatedBaseDatatrackerPersonList:

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -11,7 +11,7 @@ import rpcapi_client
 from django import forms
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Exists, Max, OuterRef, Prefetch, Q
+from django.db.models import Exists, Max, OuterRef, Prefetch, Q, Subquery
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
@@ -368,6 +368,22 @@ class RpcPersonAssignmentViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
     def get_queryset(self):
         req_person_id = int(self.kwargs["person_id"])
 
+        HistoricalRfcToBe = RfcToBe.history.model
+        enqueued_at_subquery = Subquery(
+            HistoricalRfcToBe.objects.filter(
+                id=OuterRef("rfc_to_be_id"), history_type="+"
+            )
+            .order_by("history_date")
+            .values("history_date")[:1]
+        )
+
+        HistoricalAssignment = Assignment.history.model
+        assigned_at_subquery = Subquery(
+            HistoricalAssignment.objects.filter(id=OuterRef("id"), history_type="+")
+            .order_by("history_date")
+            .values("history_date")[:1]
+        )
+
         queryset = (
             super()
             .get_queryset()
@@ -381,6 +397,10 @@ class RpcPersonAssignmentViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
                     ).select_related("reason"),
                     to_attr="blocking_reasons",
                 )
+            )
+            .annotate(
+                enqueued_at=enqueued_at_subquery,
+                assigned_at=assigned_at_subquery,
             )
         )
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1196,6 +1196,11 @@ class NestedAssignmentSerializer(AssignmentSerializer):
     """Assignment serializer with nested RfcToBe details"""
 
     rfc_to_be = RfcToBeSerializer(read_only=True)
+    enqueued_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    assigned_at = serializers.DateTimeField(read_only=True, allow_null=True)
+
+    class Meta(AssignmentSerializer.Meta):
+        fields = AssignmentSerializer.Meta.fields + ["enqueued_at", "assigned_at"]
 
 
 def _rfctobe_is_blocked(rfctobe: RfcToBe | None) -> bool:


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1351 and fix https://github.com/ietf-tools/purple/issues/1061

- apply table design like queue page
- make columns sortable and store sort order in local storage
- add "enqueue date" and "assigned date" in API client payload and in UI