### PR TITLE
fix: client generator error queue count

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -761,6 +761,7 @@ class QueueCounts(views.APIView):
     CACHE_KEY = "queue_counts"
     CACHE_TTL = 60  # seconds
 
+    @extend_schema(operation_id="queue_counts", responses={200: QueueCountsSerializer})
     def get(self, request):
         cached = cache.get(self.CACHE_KEY)
         if cached is not None:


### PR DESCRIPTION
add schema to remove ERROR in client schema generation

```
Schema generation summary:
Warnings: 143 (49 unique)
Errors:   1 (1 unique)
```