### PR TITLE
fix: resolve type-aware oxlint errors surfaced by oxlint-tsgolint

### DIFF
--- a/client/app/components/FinalReviews.vue
+++ b/client/app/components/FinalReviews.vue
@@ -49,9 +49,7 @@ const queueListWithFilters = computed(() => {
   if (!props.name) {
     return queueList.value
   }
-  return queueList.value.filter((queueItem) => {
-    queueItem.name == props.name
-  })
+  return queueList.value.filter((queueItem) => queueItem.name === props.name)
 })
 
 const ASSIGNMENT_SET_ROLE_PUBLISHER = 'publisher'

--- a/client/app/pages/docs/[id]/assignments.vue
+++ b/client/app/pages/docs/[id]/assignments.vue
@@ -219,9 +219,9 @@ const rfcToBe = computed((): CookedDraft | null => {
 watch(
   selectedLabelIds,
   async () => {
-    // spreading to ensure ref proxy objects provide primitive number values and not a wrapped proxy thing that would confuse difference()
-    const initialValues = new Set([...initialSelectedLabelIds.value])
-    const selectedValues = new Set([...selectedLabelIds.value])
+    // number arrays, so Set receives primitive number values directly (not wrapped ref proxies that would confuse difference())
+    const initialValues = new Set(initialSelectedLabelIds.value)
+    const selectedValues = new Set(selectedLabelIds.value)
 
     const areSetsSame = (a: Set<number>, b: Set<number>): boolean =>
       a.size === b.size && [...a].every((x) => b.has(x))

--- a/client/app/pages/docs/[id]/index.vue
+++ b/client/app/pages/docs/[id]/index.vue
@@ -182,9 +182,9 @@ const labels3 = computed(() => labels.value.filter((label) => label.used && !lab
 watch(
   selectedLabelIds,
   async () => {
-    // spreading to ensure ref proxy objects provide primitive number values and not a wrapped proxy thing that would confuse difference()
-    const initialValues = new Set([...initialSelectedLabelIds.value])
-    const selectedValues = new Set([...selectedLabelIds.value])
+    // number arrays, so Set receives primitive number values directly (not wrapped ref proxies that would confuse difference())
+    const initialValues = new Set(initialSelectedLabelIds.value)
+    const selectedValues = new Set(selectedLabelIds.value)
 
     const areSetsSame = (a: Set<number>, b: Set<number>): boolean =>
       a.size === b.size && [...a].every((x) => b.has(x))

--- a/client/app/utils/document_relations-utils.ts
+++ b/client/app/utils/document_relations-utils.ts
@@ -40,7 +40,7 @@ export const ref_type: Record<Relationship, string> = {
   'not-received-3g': 'not received 3g'
 } as const
 
-export const getHumanReadableRelationshipName = (relationship: Relationship | string) => {
+export const getHumanReadableRelationshipName = (relationship: string) => {
   return relationship in ref_type ? ref_type[relationship as keyof typeof ref_type] : relationship
 }
 

--- a/client/app/utils/document_relations.ts
+++ b/client/app/utils/document_relations.ts
@@ -53,9 +53,7 @@ function textRadius(lines: Line[]) {
 
 export type DrawGraphParameters = Parameters<typeof drawGraph>
 
-export type SetTooltip = (
-  props?: undefined | { text: string[]; position: [number, number] }
-) => void
+export type SetTooltip = (props?: { text: string[]; position: [number, number] }) => void
 
 type Props = {
   data: DataParam
@@ -64,7 +62,7 @@ type Props = {
   setTooltip: SetTooltip
 }
 
-export function drawGraph({ data: _data, pushRouter, colorMode, setTooltip }: Props) {
+export function drawGraph({ data: _data, pushRouter, colorMode: _colorMode, setTooltip }: Props) {
   const data = normalizeData(_data)
 
   const width = 1000

--- a/client/app/utils/queue.ts
+++ b/client/app/utils/queue.ts
@@ -1,5 +1,5 @@
 import { h } from 'vue'
-import type { Assignment, Cluster, Label, QueueItem, RfcToBe, SimpleCluster } from '~/purple_client'
+import type { Assignment, Cluster, Label, QueueItem, SimpleCluster } from '~/purple_client'
 import type { Tab } from './tab'
 import { DateTime } from 'luxon'
 

--- a/client/app/utils/snackbar.ts
+++ b/client/app/utils/snackbar.ts
@@ -23,7 +23,7 @@ export const getApiErrorMessage = async (error: unknown): Promise<string> => {
 
 export const snackbarForErrors = async ({ snackbar, error, defaultTitle }: Props) => {
   let title = defaultTitle ?? 'Error.'
-  let text = `${error}`
+  let text = String(error)
 
   console.error('Snackbar error', defaultTitle, error)
 
@@ -110,7 +110,7 @@ const getErrorTextFromFetchResponse = async (response: Response, text: string): 
         const domParser = new DOMParser()
         const dom = domParser.parseFromString(html, 'text/html')
         text = `${dom.title}. See console for more.`
-      } catch (e) {
+      } catch {
         text = html
       }
       break
@@ -126,7 +126,7 @@ const getErrorTextFromNuxtError = async (error: NuxtError, _text: string): Promi
     const keys = Object.keys(error.data)
     if (keys.length === 1) {
       const value = (error.data as Record<string, unknown>)[keys[0]!]
-      return Array.isArray(value) ? value.join(', ') : `${value}`
+      return Array.isArray(value) ? value.join(', ') : String(value)
     }
   }
   return `HTTP ${error.statusCode}: ${error.message}`

--- a/client/app/utils/url.ts
+++ b/client/app/utils/url.ts
@@ -1,4 +1,3 @@
-import type { RpcPerson } from '~/purple_client'
 import type { ResolvedQueueItem } from '../components/AssignmentsTypes'
 
 export const AUTH_PATH = '/auth'

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,6 +49,7 @@
         "nuxt-svgo": "5.3.0",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
+        "oxlint-tsgolint": "0.25.0",
         "vitest": "4.1.8",
         "vue-router": "5.1.0",
         "vue-tsc": "3.2.6"
@@ -1605,18 +1606,6 @@
         "commander": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@nuxt/cli/node_modules/fuse.js": {
@@ -3934,6 +3923,90 @@
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@oxlint-tsgolint/darwin-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-87opKlwFP8qS9WHAeETV+kA0fC9Oyj4sg7OxWdI4xQY0WC7zlN6BgG66uE5mvtN5mahkt/gL0i/AVEnX6POq2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-HJmuZexsrhqp4WmETn+Soq7Ogt5F0jirv+cYRSniIPe+d/x5beQzLX69xOLhQRE+8FLGETe7FahWMVP8x0dW4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-aNyYsPREvCJi3qjfBA0sQB7DhT3y/W5Ac2JI2D8IJynoTOAhVZj401Si6901oDajlBWyqJqqojudn0VgHB6+7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-+60+VjK9Mch3uA5WlTdNHuAm5+WA7wPPjuWdPWlU0F6JJpYpGZXUpO1RPKuFEWsBpNbLcLeJ0LbCJ1doWu58NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-r53TO+eHp/t53nnUkQJfrYYXODPAxmtf3RUFQG5XsE2hD21IunliOaAdZXP2UwzCx+r/fbNaEelqTaAHcDr57w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-vqe66B+gL9HarhyHemdlfC2VWT7eoA+o/ufZ7zT6AGHv64boyDZIJS3U+rpZo+ey4O7wZtiS/vYR2fWqDoFeBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.74.0",
@@ -13160,6 +13233,24 @@
         "vite-plus": {
           "optional": true
         }
+      }
+    },
+    "node_modules/oxlint-tsgolint": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.25.0.tgz",
+      "integrity": "sha512-7DBpqyLZCfyoXiivyfzt9Xmju/K1RcN+Y1W7buEwrgRCWWF11v9alypPqWGZBmh2erDkKL/kVyhKUH2Px+t13A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsgolint": "bin/tsgolint.js"
+      },
+      "optionalDependencies": {
+        "@oxlint-tsgolint/darwin-arm64": "0.25.0",
+        "@oxlint-tsgolint/darwin-x64": "0.25.0",
+        "@oxlint-tsgolint/linux-arm64": "0.25.0",
+        "@oxlint-tsgolint/linux-x64": "0.25.0",
+        "@oxlint-tsgolint/win32-arm64": "0.25.0",
+        "@oxlint-tsgolint/win32-x64": "0.25.0"
       }
     },
     "node_modules/package-json-from-dist": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -41,6 +41,7 @@
         "@types/node": "22.15.30",
         "@types/sortablejs": "1.15.9",
         "@vue/test-utils": "2.4.6",
+        "commander": "13.1.0",
         "globals": "17.4.0",
         "happy-dom": "20.9.0",
         "nuxt": "4.4.7",
@@ -7827,12 +7828,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {
@@ -8465,6 +8467,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/d3-ease": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -41,7 +41,6 @@
         "@types/node": "22.15.30",
         "@types/sortablejs": "1.15.9",
         "@vue/test-utils": "2.4.6",
-        "commander": "13.1.0",
         "globals": "17.4.0",
         "happy-dom": "20.9.0",
         "nuxt": "4.4.7",
@@ -56,6 +55,7 @@
         "vue-tsc": "3.2.6"
       },
       "peerDependencies": {
+        "commander": "13.1.0",
         "typescript": "6.0.2"
       }
     },
@@ -7831,8 +7831,8 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "@types/node": "22.15.30",
     "@types/sortablejs": "1.15.9",
     "@vue/test-utils": "2.4.6",
+    "commander": "13.1.0",
     "globals": "17.4.0",
     "happy-dom": "20.9.0",
     "nuxt": "4.4.7",

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,6 @@
     "@types/node": "22.15.30",
     "@types/sortablejs": "1.15.9",
     "@vue/test-utils": "2.4.6",
-    "commander": "13.1.0",
     "globals": "17.4.0",
     "happy-dom": "20.9.0",
     "nuxt": "4.4.7",
@@ -65,6 +64,7 @@
     "vue-tsc": "3.2.6"
   },
   "peerDependencies": {
+    "commander": "13.1.0",
     "typescript": "6.0.2"
   },
   "allowScripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -58,6 +58,7 @@
     "nuxt-svgo": "5.3.0",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
+    "oxlint-tsgolint": "0.25.0",
     "vitest": "4.1.8",
     "vue-router": "5.1.0",
     "vue-tsc": "3.2.6"


### PR DESCRIPTION
Enabling oxlint's type-aware rules (via the oxlint-tsgolint engine) surfaced 13 pre-existing errors across 8 files. None are behavioural except the first:

- FinalReviews: the queue filter callback used a block body but never returned, so `queueItem.name == props.name` was dead and the filter dropped every item; return the (strict) comparison instead
- drop unused imports/bindings: RpcPerson (url), RfcToBe (queue), the catch binding (snackbar), and mark colorMode unused (document_relations)
- use String(...) instead of template literals on unknown values (snackbar)
- new Set(x) instead of new Set([...x]) — no-useless-spread (docs pages)
- drop redundant type constituents: `Relationship | string` -> `string`, and the explicit `undefined` on an optional param (document_relations)

Co-Authored-By: Claude