### PR TITLE
feat: provide names (not only slug) for UI

### DIFF
--- a/client/app/components/DocHeader.vue
+++ b/client/app/components/DocHeader.vue
@@ -34,7 +34,7 @@
             <Icon name="solar:document-text-line-duotone" class="w-10 h-10" />
             <h1>
               <span class="mt-1 text-xl font-semibold leading-6">
-                <template v-if="props.rfcToBe?.disposition === 'published'">
+                <template v-if="props.rfcToBe?.disposition?.slug === 'published'">
                   <span v-if="props.rfcToBe?.rfcNumber"
                     >RFC {{ props.rfcToBe?.rfcNumber
                     }}<template v-if="isAprilFirst">
@@ -82,7 +82,7 @@
             </span>
           </BaseButton>
           <BaseButton
-            v-if="props.rfcToBe?.disposition === 'in_progress'"
+            v-if="props.rfcToBe?.disposition?.slug === 'in_progress'"
             btn-type="delete"
             @click="isWithdrawDialogShown = true"
             class="flex items-center">

--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -19,7 +19,7 @@
               :on-success="props.refresh">
               <div class="flex items-center gap-2">
                 <BaseBadge
-                  :label="rfcToBe.disposition"
+                  :label="rfcToBe.dispositionName ?? rfcToBe.disposition"
                   :color="dispositionColor(rfcToBe.disposition)" />
                 <template
                   v-if="
@@ -173,10 +173,10 @@
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
               <span class="flex-1">
-                {{ rfcToBe.stream }}
+                {{ rfcToBe.streamName ?? rfcToBe.stream }}
                 <span
                   v-if="rfcToBe.publicationStream && rfcToBe.publicationStream !== rfcToBe.stream">
-                  (published as {{ rfcToBe.publicationStream }})
+                  (published as {{ rfcToBe.publicationStreamName ?? rfcToBe.publicationStream }})
                 </span>
               </span>
             </PatchRfcToBeField>
@@ -202,7 +202,7 @@
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
-              {{ rfcToBe.submittedFormat }}
+              {{ rfcToBe.submittedFormatName ?? rfcToBe.submittedFormat }}
             </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>
@@ -218,7 +218,7 @@
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
-              {{ rfcToBe.boilerplate }}
+              {{ rfcToBe.boilerplateName ?? rfcToBe.boilerplate }}
             </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>
@@ -234,12 +234,12 @@
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
-              {{ rfcToBe.stdLevel }}
+              {{ rfcToBe.stdLevelName ?? rfcToBe.stdLevel }}
               <span
                 v-if="
                   rfcToBe.publicationStdLevel && rfcToBe.publicationStdLevel !== rfcToBe.stdLevel
                 ">
-                (published as {{ rfcToBe.publicationStdLevel }})
+                (published as {{ rfcToBe.publicationStdLevelName ?? rfcToBe.publicationStdLevel }})
               </span>
               <span
                 v-if="

--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -8,22 +8,21 @@
         <DescriptionListItem term="Disposition" :spacing="spacing">
           <DescriptionListDetails>
             <PatchRfcToBeField
-              fieldName="disposition"
               :is-read-only="true"
               :ui-mode="{
                 type: 'select',
                 options: dispositionOptions,
-                initialValue: rfcToBe.disposition
+                initialValue: rfcToBe.disposition?.slug
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
               <div class="flex items-center gap-2">
                 <BaseBadge
-                  :label="rfcToBe.dispositionName ?? rfcToBe.disposition"
-                  :color="dispositionColor(rfcToBe.disposition)" />
+                  :label="rfcToBe.disposition?.name ?? rfcToBe.disposition?.slug"
+                  :color="dispositionColor(rfcToBe.disposition?.slug)" />
                 <template
                   v-if="
-                    rfcToBe.disposition === 'in_progress' &&
+                    rfcToBe.disposition?.slug === 'in_progress' &&
                     rfcToBe.blockingReasons?.some((r) => r.resolved == null)
                   ">
                   <BaseBadge label="blocked" color="red" />
@@ -36,7 +35,7 @@
                   </ul>
                 </template>
                 <span
-                  v-if="rfcToBe.disposition === 'published' && rfcToBe.publishedAt"
+                  v-if="rfcToBe.disposition?.slug === 'published' && rfcToBe.publishedAt"
                   class="text-sm text-gray-600">
                   {{ DateTime.fromJSDate(rfcToBe.publishedAt).toLocaleString(DateTime.DATE_FULL) }}
                 </span>
@@ -167,16 +166,24 @@
         <DescriptionListItem term="Stream" :spacing="spacing">
           <DescriptionListDetails>
             <PatchRfcToBeField
-              fieldName="stream"
+              fieldName="streamSlug"
               :is-read-only="false"
-              :ui-mode="{ type: 'select', options: loadStreams, initialValue: rfcToBe.stream }"
+              :ui-mode="{
+                type: 'select',
+                options: loadStreams,
+                initialValue: rfcToBe.stream?.slug
+              }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
               <span class="flex-1">
-                {{ rfcToBe.streamName ?? rfcToBe.stream }}
+                {{ rfcToBe.stream?.name ?? rfcToBe.stream?.slug }}
                 <span
-                  v-if="rfcToBe.publicationStream && rfcToBe.publicationStream !== rfcToBe.stream">
-                  (published as {{ rfcToBe.publicationStreamName ?? rfcToBe.publicationStream }})
+                  v-if="
+                    rfcToBe.publicationStream &&
+                    rfcToBe.publicationStream.slug !== rfcToBe.stream?.slug
+                  ">
+                  (published as
+                  {{ rfcToBe.publicationStream.name ?? rfcToBe.publicationStream.slug }})
                 </span>
               </span>
             </PatchRfcToBeField>
@@ -193,60 +200,62 @@
         <DescriptionListItem term="Submitted Format" :spacing="spacing">
           <DescriptionListDetails>
             <PatchRfcToBeField
-              fieldName="submittedFormat"
+              fieldName="submittedFormatSlug"
               :is-read-only="props.isReadOnly"
               :ui-mode="{
                 type: 'select',
                 options: loadFormats,
-                initialValue: rfcToBe.submittedFormat
+                initialValue: rfcToBe.submittedFormat?.slug
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
-              {{ rfcToBe.submittedFormatName ?? rfcToBe.submittedFormat }}
+              {{ rfcToBe.submittedFormat?.name ?? rfcToBe.submittedFormat?.slug }}
             </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>
         <DescriptionListItem term="Boilerplate" :spacing="spacing">
           <DescriptionListDetails>
             <PatchRfcToBeField
-              fieldName="boilerplate"
+              fieldName="boilerplateSlug"
               :is-read-only="props.isReadOnly"
               :ui-mode="{
                 type: 'select',
                 options: loadBoilerplates,
-                initialValue: rfcToBe.boilerplate
+                initialValue: rfcToBe.boilerplate?.slug
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
-              {{ rfcToBe.boilerplateName ?? rfcToBe.boilerplate }}
+              {{ rfcToBe.boilerplate?.name ?? rfcToBe.boilerplate?.slug }}
             </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>
         <DescriptionListItem term="Status" :spacing="spacing">
           <DescriptionListDetails>
             <PatchRfcToBeField
-              fieldName="stdLevel"
+              fieldName="stdLevelSlug"
               :is-read-only="false"
               :ui-mode="{
                 type: 'select',
                 options: loadStandardLevels,
-                initialValue: rfcToBe.stdLevel
+                initialValue: rfcToBe.stdLevel?.slug
               }"
               :draft-name="rfcToBe.name ?? ''"
               :on-success="props.refresh">
-              {{ rfcToBe.stdLevelName ?? rfcToBe.stdLevel }}
+              {{ rfcToBe.stdLevel?.name ?? rfcToBe.stdLevel?.slug }}
               <span
                 v-if="
-                  rfcToBe.publicationStdLevel && rfcToBe.publicationStdLevel !== rfcToBe.stdLevel
+                  rfcToBe.publicationStdLevel &&
+                  rfcToBe.publicationStdLevel.slug !== rfcToBe.stdLevel?.slug
                 ">
-                (published as {{ rfcToBe.publicationStdLevelName ?? rfcToBe.publicationStdLevel }})
+                (published as
+                {{ rfcToBe.publicationStdLevel.name ?? rfcToBe.publicationStdLevel.slug }})
               </span>
               <span
                 v-if="
                   rfcToBe.draft?.intendedStdLevel &&
-                  rfcToBe.draft?.intendedStdLevel !== rfcToBe.stdLevel
+                  rfcToBe.draft?.intendedStdLevel.slug !== rfcToBe.stdLevel?.slug
                 ">
-                (draft intended as {{ rfcToBe.draft?.intendedStdLevel }})
+                (draft intended as {{ rfcToBe.draft?.intendedStdLevel.name }})
               </span>
             </PatchRfcToBeField>
           </DescriptionListDetails>

--- a/client/app/components/DocumentDependencies.vue
+++ b/client/app/components/DocumentDependencies.vue
@@ -53,7 +53,7 @@ const columns: Column[] = [
   {
     key: 'relationship',
     label: 'Relationship',
-    field: 'relationship' satisfies keyof RpcRelatedDocument,
+    field: 'relationshipName' satisfies keyof RpcRelatedDocument,
     classes: 'text-sm font-medium'
   },
   {

--- a/client/app/components/DocumentsSearch.vue
+++ b/client/app/components/DocumentsSearch.vue
@@ -56,7 +56,7 @@
               <span
                 class="font-normal ml-1 text-gray-500 dark:text-gray-400"
                 v-if="searchResult.disposition">
-                ({{ searchResult.disposition }})
+                ({{ searchResult.dispositionName ?? searchResult.disposition }})
               </span>
             </ComboboxItem>
           </ComboboxViewport>

--- a/client/app/components/DocumentsSearch.vue
+++ b/client/app/components/DocumentsSearch.vue
@@ -56,7 +56,7 @@
               <span
                 class="font-normal ml-1 text-gray-500 dark:text-gray-400"
                 v-if="searchResult.disposition">
-                ({{ searchResult.dispositionName ?? searchResult.disposition }})
+                ({{ searchResult.disposition?.name ?? searchResult.disposition?.slug }})
               </span>
             </ComboboxItem>
           </ComboboxViewport>

--- a/client/app/components/HeaderNav.vue
+++ b/client/app/components/HeaderNav.vue
@@ -65,7 +65,7 @@
                   v-if="doc.disposition"
                   :class="dispositionClass(doc.disposition)"
                   class="ml-auto shrink-0 rounded-full px-2 py-0.5 text-xs font-medium"
-                  >{{ doc.disposition }}</span
+                  >{{ doc.dispositionName ?? doc.disposition }}</span
                 >
               </button>
             </li>

--- a/client/app/components/HeaderNav.vue
+++ b/client/app/components/HeaderNav.vue
@@ -63,9 +63,9 @@
                 >
                 <span
                   v-if="doc.disposition"
-                  :class="dispositionClass(doc.disposition)"
+                  :class="dispositionClass(doc.disposition?.slug)"
                   class="ml-auto shrink-0 rounded-full px-2 py-0.5 text-xs font-medium"
-                  >{{ doc.dispositionName ?? doc.disposition }}</span
+                  >{{ doc.disposition?.name ?? doc.disposition?.slug }}</span
                 >
               </button>
             </li>
@@ -296,12 +296,12 @@ const onSearchBlur = () => {
 }
 
 const selectDoc = (doc: NonNullable<DocumentsSearchResponse['results']>[number]) => {
-  navigateTo(`/docs/${doc.disposition === 'withdrawn' ? doc.id : doc.name}`)
+  navigateTo(`/docs/${doc.disposition?.slug === 'withdrawn' ? doc.id : doc.name}`)
   navSearch.value = ''
   showResults.value = false
 }
 
-const dispositionClass = (disposition: string) => {
+const dispositionClass = (disposition: string | undefined) => {
   switch (disposition) {
     case 'created':
       return 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'

--- a/client/app/components/PatchRfcToBeField.vue
+++ b/client/app/components/PatchRfcToBeField.vue
@@ -150,7 +150,7 @@ type Props = {
   draftName: NonNullable<RfcToBe['name']>
   isReadOnly: boolean
   uiMode: UIMode
-  fieldName: keyof PatchedRfcToBeRequest
+  fieldName?: keyof PatchedRfcToBeRequest
   onSuccess?: () => Promise<void>
 }
 

--- a/client/app/components/WithdrawDraftDialog.vue
+++ b/client/app/components/WithdrawDraftDialog.vue
@@ -118,7 +118,7 @@ const handleWithdraw = async () => {
   try {
     await api.documentsPartialUpdate({
       draftName: props.draftName,
-      patchedRfcToBeRequest: { disposition: 'withdrawn' }
+      patchedRfcToBeRequest: { dispositionSlug: 'withdrawn' }
     })
   } catch (error: unknown) {
     snackbarForErrors({ snackbar, defaultTitle: 'Withdrawing draft failed', error })

--- a/client/app/pages/docs/[id]/index.vue
+++ b/client/app/pages/docs/[id]/index.vue
@@ -47,7 +47,7 @@
         </div>
 
         <div
-          v-if="rawRfcToBe?.id && rawRfcToBe.disposition !== 'published'"
+          v-if="rawRfcToBe?.id && rawRfcToBe.disposition?.slug !== 'published'"
           class="lg:col-span-full grid place-items-stretch">
           <DocumentDependencies
             v-model="relatedDocuments"

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -382,7 +382,7 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
     return
   }
 
-  if (rfcToBe.value?.disposition === 'published') {
+  if (rfcToBe.value?.disposition?.slug === 'published') {
     step.value = { type: 'alreadyPublished' }
     return
   }
@@ -454,7 +454,7 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
     }
   }
 
-  if (rfcToBe.value?.disposition === 'published') {
+  if (rfcToBe.value?.disposition?.slug === 'published') {
     step.value = { type: 'rfcPosted' }
     return
   } else {

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -6342,6 +6342,9 @@ components:
           readOnly: true
         relationship:
           type: string
+        relationship_name:
+          type: string
+          readOnly: true
         draft_name:
           type: string
           readOnly: true

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5483,6 +5483,9 @@ components:
         stream:
           type: string
           description: Current stream
+        stream_name:
+          type: string
+          readOnly: true
         group:
           type: string
           description: Acronym of datatracker group where this document originated,
@@ -5976,6 +5979,9 @@ components:
           readOnly: true
         disposition:
           type: string
+        disposition_name:
+          type: string
+          readOnly: true
         external_deadline:
           type: string
           format: date-time
@@ -5994,6 +6000,9 @@ components:
           readOnly: true
         submitted_format:
           type: string
+        submitted_format_name:
+          type: string
+          readOnly: true
         pages:
           type: integer
           maximum: 2147483647
@@ -6007,20 +6016,35 @@ components:
         boilerplate:
           type: string
           description: TLP IPR boilerplate option
+        boilerplate_name:
+          type: string
+          readOnly: true
         std_level:
           type: string
           description: Current StdLevel
+        std_level_name:
+          type: string
+          readOnly: true
         publication_std_level:
           type: string
           nullable: true
           description: StdLevel at publication (blank until published)
+        publication_std_level_name:
+          type: string
+          readOnly: true
         stream:
           type: string
           description: Current stream
+        stream_name:
+          type: string
+          readOnly: true
         publication_stream:
           type: string
           nullable: true
           description: Stream at publication (blank until published)
+        publication_stream_name:
+          type: string
+          readOnly: true
         authors:
           type: array
           items:

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5486,6 +5486,12 @@ components:
         stream_name:
           type: string
           readOnly: true
+        std_level_name:
+          type: string
+          readOnly: true
+        disposition_name:
+          type: string
+          readOnly: true
         group:
           type: string
           description: Acronym of datatracker group where this document originated,

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -4452,7 +4452,9 @@ components:
           readOnly: true
           description: Number of pages
         intended_std_level:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
+          nullable: true
           readOnly: true
     FinalApproval:
       type: object
@@ -4872,6 +4874,27 @@ components:
         - desc
         - name
         - slug
+    NameRequest:
+      type: object
+      description: Serialize any Name subclass
+      properties:
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 32
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        desc:
+          type: string
+        used:
+          type: boolean
+          default: true
+      required:
+        - desc
+        - name
+        - slug
     NestedAssignment:
       type: object
       description: Assignment serializer with nested RfcToBe details
@@ -5143,9 +5166,10 @@ components:
           description: Acronym of datatracker group where this document originated,
             if any
           maxLength: 40
-        disposition:
+        disposition_slug:
           type: string
           minLength: 1
+          writeOnly: true
         external_deadline:
           type: string
           format: date-time
@@ -5158,9 +5182,10 @@ components:
           type: array
           items:
             type: integer
-        submitted_format:
+        submitted_format_slug:
           type: string
           minLength: 1
+          writeOnly: true
         pages:
           type: integer
           maximum: 2147483647
@@ -5171,28 +5196,18 @@ components:
           type: string
           description: Comma-separated list of keywords
           maxLength: 1000
-        boilerplate:
+        boilerplate_slug:
           type: string
           minLength: 1
-          description: TLP IPR boilerplate option
-        std_level:
+          writeOnly: true
+        std_level_slug:
           type: string
           minLength: 1
-          description: Current StdLevel
-        publication_std_level:
+          writeOnly: true
+        stream_slug:
           type: string
           minLength: 1
-          nullable: true
-          description: StdLevel at publication (blank until published)
-        stream:
-          type: string
-          minLength: 1
-          description: Current stream
-        publication_stream:
-          type: string
-          minLength: 1
-          nullable: true
-          description: Stream at publication (blank until published)
+          writeOnly: true
         authors:
           type: array
           items:
@@ -5984,9 +5999,8 @@ components:
             - $ref: "#/components/schemas/Draft"
           readOnly: true
         disposition:
-          type: string
-        disposition_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         external_deadline:
           type: string
@@ -6005,9 +6019,8 @@ components:
             - $ref: "#/components/schemas/SimpleCluster"
           readOnly: true
         submitted_format:
-          type: string
-        submitted_format_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         pages:
           type: integer
@@ -6020,36 +6033,24 @@ components:
           description: Comma-separated list of keywords
           maxLength: 1000
         boilerplate:
-          type: string
-          description: TLP IPR boilerplate option
-        boilerplate_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         std_level:
-          type: string
-          description: Current StdLevel
-        std_level_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         publication_std_level:
-          type: string
-          nullable: true
-          description: StdLevel at publication (blank until published)
-        publication_std_level_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         stream:
-          type: string
-          description: Current stream
-        stream_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         publication_stream:
-          type: string
-          nullable: true
-          description: Stream at publication (blank until published)
-        publication_stream_name:
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/Name"
           readOnly: true
         authors:
           type: array
@@ -6131,12 +6132,7 @@ components:
           maxLength: 16
       required:
         - authors
-        - boilerplate
-        - disposition
         - labels
-        - std_level
-        - stream
-        - submitted_format
         - title
     RfcToBeBlockingReason:
       type: object
@@ -6183,9 +6179,10 @@ components:
           description: Acronym of datatracker group where this document originated,
             if any
           maxLength: 40
-        disposition:
+        disposition_slug:
           type: string
           minLength: 1
+          writeOnly: true
         external_deadline:
           type: string
           format: date-time
@@ -6198,9 +6195,10 @@ components:
           type: array
           items:
             type: integer
-        submitted_format:
+        submitted_format_slug:
           type: string
           minLength: 1
+          writeOnly: true
         pages:
           type: integer
           maximum: 2147483647
@@ -6211,28 +6209,18 @@ components:
           type: string
           description: Comma-separated list of keywords
           maxLength: 1000
-        boilerplate:
+        boilerplate_slug:
           type: string
           minLength: 1
-          description: TLP IPR boilerplate option
-        std_level:
+          writeOnly: true
+        std_level_slug:
           type: string
           minLength: 1
-          description: Current StdLevel
-        publication_std_level:
+          writeOnly: true
+        stream_slug:
           type: string
           minLength: 1
-          nullable: true
-          description: StdLevel at publication (blank until published)
-        stream:
-          type: string
-          minLength: 1
-          description: Current stream
-        publication_stream:
-          type: string
-          minLength: 1
-          nullable: true
-          description: Stream at publication (blank until published)
+          writeOnly: true
         authors:
           type: array
           items:
@@ -6288,12 +6276,7 @@ components:
           maxLength: 16
       required:
         - authors
-        - boilerplate
-        - disposition
         - labels
-        - std_level
-        - stream
-        - submitted_format
         - title
     RpcPerson:
       type: object

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -6036,22 +6036,27 @@ components:
           allOf:
             - $ref: "#/components/schemas/Name"
           readOnly: true
+          description: TLP IPR boilerplate option
         std_level:
           allOf:
             - $ref: "#/components/schemas/Name"
           readOnly: true
+          description: Current StdLevel
         publication_std_level:
           allOf:
             - $ref: "#/components/schemas/Name"
           readOnly: true
+          description: StdLevel at publication (blank until published)
         stream:
           allOf:
             - $ref: "#/components/schemas/Name"
           readOnly: true
+          description: Current stream
         publication_stream:
           allOf:
             - $ref: "#/components/schemas/Name"
           readOnly: true
+          description: Stream at publication (blank until published)
         authors:
           type: array
           items:

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -915,6 +915,29 @@ class RfcToBeSerializer(serializers.ModelSerializer):
         source="additionalemail_set", many=True, read_only=True
     )
     blocking_reasons = RfcToBeBlockingReasonSerializer(many=True, read_only=True)
+    # Human-readable names for the slug-valued FK fields, for display. The plain
+    # slug fields stay writable for editing.
+    disposition_name = serializers.SlugRelatedField(
+        source="disposition", slug_field="name", read_only=True
+    )
+    stream_name = serializers.SlugRelatedField(
+        source="stream", slug_field="name", read_only=True
+    )
+    publication_stream_name = serializers.SlugRelatedField(
+        source="publication_stream", slug_field="name", read_only=True
+    )
+    std_level_name = serializers.SlugRelatedField(
+        source="std_level", slug_field="name", read_only=True
+    )
+    publication_std_level_name = serializers.SlugRelatedField(
+        source="publication_std_level", slug_field="name", read_only=True
+    )
+    boilerplate_name = serializers.SlugRelatedField(
+        source="boilerplate", slug_field="name", read_only=True
+    )
+    submitted_format_name = serializers.SlugRelatedField(
+        source="submitted_format", slug_field="name", read_only=True
+    )
     pub_owner = serializers.SerializerMethodField()
 
     @extend_schema_field(serializers.CharField(allow_null=True))
@@ -941,18 +964,25 @@ class RfcToBeSerializer(serializers.ModelSerializer):
             "group",
             "draft",
             "disposition",
+            "disposition_name",
             "external_deadline",
             "internal_goal",
             "labels",
             "cluster",
             "submitted_format",
+            "submitted_format_name",
             "pages",
             "keywords",
             "boilerplate",
+            "boilerplate_name",
             "std_level",
+            "std_level_name",
             "publication_std_level",
+            "publication_std_level_name",
             "stream",
+            "stream_name",
             "publication_stream",
+            "publication_stream_name",
             "authors",
             "shepherd",
             "shepherd_id",
@@ -2526,6 +2556,9 @@ class PublicQueueItemSerializer(QueueItemSerializer):
     references = serializers.SerializerMethodField()
     group_name = serializers.SerializerMethodField()
     rev = serializers.CharField(source="draft.rev", read_only=True, allow_null=True)
+    stream_name = serializers.SlugRelatedField(
+        source="stream", slug_field="name", read_only=True
+    )
 
     @extend_schema_field(RpcRelatedDocumentSerializer(many=True))
     def get_references(self, obj):
@@ -2565,6 +2598,7 @@ class PublicQueueItemSerializer(QueueItemSerializer):
             "authors",
             "approval_log_message",
             "stream",
+            "stream_name",
             "group",
             "group_name",
             "std_level",

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -915,8 +915,6 @@ class RfcToBeSerializer(serializers.ModelSerializer):
         source="additionalemail_set", many=True, read_only=True
     )
     blocking_reasons = RfcToBeBlockingReasonSerializer(many=True, read_only=True)
-    # Human-readable names for the slug-valued FK fields, for display. The plain
-    # slug fields stay writable for editing.
     disposition_name = serializers.SlugRelatedField(
         source="disposition", slug_field="name", read_only=True
     )
@@ -1423,12 +1421,16 @@ class RpcRelatedDocumentSerializer(serializers.ModelSerializer):
     target_disposition = serializers.SerializerMethodField()
     target_is_received = serializers.SerializerMethodField()
     target_is_blocked = serializers.SerializerMethodField()
+    relationship_name = serializers.SlugRelatedField(
+        source="relationship", slug_field="name", read_only=True
+    )
 
     class Meta:
         model = RpcRelatedDocument
         fields = [
             "id",
             "relationship",
+            "relationship_name",
             "draft_name",
             "target_draft_name",
             "target_rfc_number",

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -930,11 +930,15 @@ class RfcToBeSerializer(serializers.ModelSerializer):
     )
     blocking_reasons = RfcToBeBlockingReasonSerializer(many=True, read_only=True)
     disposition = NameSerializer(read_only=True)
-    stream = NameSerializer(read_only=True)
-    publication_stream = NameSerializer(read_only=True)
-    std_level = NameSerializer(read_only=True)
-    publication_std_level = NameSerializer(read_only=True)
-    boilerplate = NameSerializer(read_only=True)
+    stream = NameSerializer(read_only=True, help_text="Current stream")
+    publication_stream = NameSerializer(
+        read_only=True, help_text="Stream at publication (blank until published)"
+    )
+    std_level = NameSerializer(read_only=True, help_text="Current StdLevel")
+    publication_std_level = NameSerializer(
+        read_only=True, help_text="StdLevel at publication (blank until published)"
+    )
+    boilerplate = NameSerializer(read_only=True, help_text="TLP IPR boilerplate option")
     submitted_format = NameSerializer(read_only=True)
 
     disposition_slug = serializers.SlugRelatedField(

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -54,6 +54,7 @@ from .models import (
     StreamName,
     SubseriesMember,
     SubseriesTypeName,
+    TlpBoilerplateChoiceName,
     UnusableRfcNumber,
 )
 from .tasks import compute_deep_references_task
@@ -558,6 +559,8 @@ class RpcRoleSerializer(serializers.ModelSerializer):
 
 
 class DraftSerializer(serializers.ModelSerializer):
+    intended_std_level = serializers.SerializerMethodField()
+
     class Meta:
         model = Document
         fields = [
@@ -567,7 +570,18 @@ class DraftSerializer(serializers.ModelSerializer):
             "pages",
             "intended_std_level",
         ]
-        read_only_fields = fields
+        read_only_fields = ["name", "rev", "title", "pages"]
+
+    @extend_schema_field(NameSerializer(allow_null=True))
+    def get_intended_std_level(self, obj):
+        slug = obj.intended_std_level
+        if not slug:
+            return None
+        # Fall back to a transient name if the slug isn't a known StdLevelName.
+        std_level = StdLevelName.objects.filter(slug=slug).first() or StdLevelName(
+            slug=slug, name=slug
+        )
+        return NameSerializer(std_level).data
 
 
 class SimpleClusterSerializer(serializers.ModelSerializer):
@@ -915,26 +929,48 @@ class RfcToBeSerializer(serializers.ModelSerializer):
         source="additionalemail_set", many=True, read_only=True
     )
     blocking_reasons = RfcToBeBlockingReasonSerializer(many=True, read_only=True)
-    disposition_name = serializers.SlugRelatedField(
-        source="disposition", slug_field="name", read_only=True
+    disposition = NameSerializer(read_only=True)
+    stream = NameSerializer(read_only=True)
+    publication_stream = NameSerializer(read_only=True)
+    std_level = NameSerializer(read_only=True)
+    publication_std_level = NameSerializer(read_only=True)
+    boilerplate = NameSerializer(read_only=True)
+    submitted_format = NameSerializer(read_only=True)
+
+    disposition_slug = serializers.SlugRelatedField(
+        source="disposition",
+        slug_field="slug",
+        queryset=DispositionName.objects.all(),
+        write_only=True,
+        required=False,
     )
-    stream_name = serializers.SlugRelatedField(
-        source="stream", slug_field="name", read_only=True
+    stream_slug = serializers.SlugRelatedField(
+        source="stream",
+        slug_field="slug",
+        queryset=StreamName.objects.all(),
+        write_only=True,
+        required=False,
     )
-    publication_stream_name = serializers.SlugRelatedField(
-        source="publication_stream", slug_field="name", read_only=True
+    std_level_slug = serializers.SlugRelatedField(
+        source="std_level",
+        slug_field="slug",
+        queryset=StdLevelName.objects.all(),
+        write_only=True,
+        required=False,
     )
-    std_level_name = serializers.SlugRelatedField(
-        source="std_level", slug_field="name", read_only=True
+    boilerplate_slug = serializers.SlugRelatedField(
+        source="boilerplate",
+        slug_field="slug",
+        queryset=TlpBoilerplateChoiceName.objects.all(),
+        write_only=True,
+        required=False,
     )
-    publication_std_level_name = serializers.SlugRelatedField(
-        source="publication_std_level", slug_field="name", read_only=True
-    )
-    boilerplate_name = serializers.SlugRelatedField(
-        source="boilerplate", slug_field="name", read_only=True
-    )
-    submitted_format_name = serializers.SlugRelatedField(
-        source="submitted_format", slug_field="name", read_only=True
+    submitted_format_slug = serializers.SlugRelatedField(
+        source="submitted_format",
+        slug_field="slug",
+        queryset=SourceFormatName.objects.all(),
+        write_only=True,
+        required=False,
     )
     pub_owner = serializers.SerializerMethodField()
 
@@ -962,25 +998,23 @@ class RfcToBeSerializer(serializers.ModelSerializer):
             "group",
             "draft",
             "disposition",
-            "disposition_name",
+            "disposition_slug",
             "external_deadline",
             "internal_goal",
             "labels",
             "cluster",
             "submitted_format",
-            "submitted_format_name",
+            "submitted_format_slug",
             "pages",
             "keywords",
             "boilerplate",
-            "boilerplate_name",
+            "boilerplate_slug",
             "std_level",
-            "std_level_name",
+            "std_level_slug",
             "publication_std_level",
-            "publication_std_level_name",
             "stream",
-            "stream_name",
+            "stream_slug",
             "publication_stream",
-            "publication_stream_name",
             "authors",
             "shepherd",
             "shepherd_id",

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -2561,6 +2561,12 @@ class PublicQueueItemSerializer(QueueItemSerializer):
     stream_name = serializers.SlugRelatedField(
         source="stream", slug_field="name", read_only=True
     )
+    std_level_name = serializers.SlugRelatedField(
+        source="std_level", slug_field="name", read_only=True
+    )
+    disposition_name = serializers.SlugRelatedField(
+        source="disposition", slug_field="name", read_only=True
+    )
 
     @extend_schema_field(RpcRelatedDocumentSerializer(many=True))
     def get_references(self, obj):
@@ -2601,6 +2607,8 @@ class PublicQueueItemSerializer(QueueItemSerializer):
             "approval_log_message",
             "stream",
             "stream_name",
+            "std_level_name",
+            "disposition_name",
             "group",
             "group_name",
             "std_level",

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -439,4 +439,4 @@ class DocumentSearchTests(TestCase):
         self.assertEqual(payload["count"], 1)
         self.assertEqual(len(payload["results"]), 1)
         self.assertEqual(payload["results"][0]["id"], in_progress.id)
-        self.assertEqual(payload["results"][0]["disposition"], "in_progress")
+        self.assertEqual(payload["results"][0]["disposition"]["slug"], "in_progress")


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/1417 and fix https://github.com/ietf-tools/purple/issues/1430
display in UI the NAME instead of the slug, for disposition, relationships, std_level and stream.
also expose these as ADDITIONAL fields in pubq API

needs additionally a DB change for stream name -> DONE 