### PR TITLE
feat: use explicit rules for ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ indent-style = "space" # Use spaces for indentation
 quote-style = "double"
 
 [tool.ruff.lint]
-extend-select = [
+select = [
   "E", # pycodestyle
   "F", # Pyflakes
   "UP", # pyupgrade
@@ -15,7 +15,7 @@ extend-select = [
   "I", # isort
   "RUF100", # unused-noqa
 ]
-extend-ignore = [
+ignore = [
   "F405", # variable may be undefined, or defined from star imports
   "F403", # unable to detect undefined names
 ]


### PR DESCRIPTION
`ruff check ` failed after update from ruff v0.14 to v0.16+, which changed the default rules.

Before this fix, lint reported 190+ errors.

By defining the explicit rules to use, and not relying on defaults, the test passes again.

While I see advantage of using the defaults, this would require many code changes here.
