### PR TITLE
feat: add pill and color for DEV mode

### DIFF
--- a/client/app/components/DevModeBadge.vue
+++ b/client/app/components/DevModeBadge.vue
@@ -1,0 +1,12 @@
+<template>
+  <span
+    v-if="isDevMode"
+    class="absolute right-3 top-1/2 -translate-y-1/2 rounded bg-amber-950 px-1.5 py-px text-[10px] font-bold uppercase leading-4 tracking-wide text-amber-50"
+    title="Local development server (npm run dev)">
+    Dev
+  </span>
+</template>
+
+<script setup lang="ts">
+import { isDevMode } from '~/utils/devMode'
+</script>

--- a/client/app/components/SidebarNav.vue
+++ b/client/app/components/SidebarNav.vue
@@ -41,10 +41,10 @@
               </div>
             </HeadlessTransitionChild>
             <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-white px-6 pb-2">
-              <div
-                class="flex h-16 shrink-0 items-center text-violet-500 dark:text-violet-300 font-light">
+              <div :class="['flex h-16 shrink-0 items-center font-light', brandingClass]">
                 <SvgoRpcIcon filled class="mr-2 text-xl" />
                 RFC Production Center
+                <DevModeBadge />
               </div>
               <nav class="flex flex-1 flex-col">
                 <ul role="list" class="flex flex-1 flex-col gap-y-7">
@@ -124,9 +124,10 @@
     <!-- Sidebar component, swap this element with another sidebar if you like -->
     <div
       class="flex grow flex-col gap-y-5 overflow-y-auto border-r border-gray-200 dark:border-violet-600 bg-white dark:bg-violet-900 bg-gradient-to-tr from-violet-50 to-white dark:from-violet-950 dark:to-violet-900 px-6">
-      <div class="flex h-16 shrink-0 items-center text-violet-500 dark:text-violet-300 font-light">
+      <div :class="['flex h-16 shrink-0 items-center font-light', brandingClass]">
         <SvgoRpcIcon filled class="mr-2 text-xl" />
         <span class="font-medium mr-1">RFC</span> Production Center
+        <DevModeBadge />
       </div>
       <nav class="flex flex-1 flex-col">
         <ul role="list" class="flex flex-1 flex-col gap-y-7">
@@ -222,6 +223,13 @@
 import { useSiteStore } from '@/stores/site'
 import { Icon } from '#components'
 import confetti from 'canvas-confetti'
+import { isDevMode } from '~/utils/devMode'
+
+// Bright banner so a local dev server is never mistaken for production.
+// -mx-6/px-6 cancels the sidebar padding so the color spans the full width.
+const brandingClass = isDevMode
+  ? 'relative -mx-6 px-6 bg-amber-400 text-amber-950'
+  : 'text-violet-500 dark:text-violet-300'
 
 // STORES
 

--- a/client/app/utils/devMode.ts
+++ b/client/app/utils/devMode.ts
@@ -1,0 +1,2 @@
+// Replaced at build time, so dev-only UI is stripped from deployed bundles
+export const isDevMode = import.meta.dev

--- a/client/app/utils/head.ts
+++ b/client/app/utils/head.ts
@@ -11,7 +11,10 @@ export const useDefaultHead = () => {
       class: 'h-full'
     },
     titleTemplate: (titleChunk) => {
-      return titleChunk ? `${titleChunk} - RFC Production Center` : 'RFC Production Center'
+      const prefix = import.meta.dev ? '[DEV] ' : ''
+      return titleChunk
+        ? `${prefix}${titleChunk} - RFC Production Center`
+        : `${prefix}RFC Production Center`
     }
   })
 }


### PR DESCRIPTION
<img width="671" height="267" alt="image" src="https://github.com/user-attachments/assets/ee84d50d-4fc0-4cd3-b5f5-44bfdae90c3f" />

adding visual marker to say I'm in DEV mode... to prevent making changes on PROD accidentally while doing testing on DEV

also add `[DEV]` in page title for dev mode