### PR TITLE
feat: use role names instead of slugs

### DIFF
--- a/client/app/components/AssignmentFinishedModal.vue
+++ b/client/app/components/AssignmentFinishedModal.vue
@@ -36,7 +36,7 @@
           :key="role"
           class="w-full flex mx-1 flex-row gap-4 items-start">
           <div class="w-[15em] shrink-0 flex items-start">
-            <BaseBadge :label="role" size="xl"></BaseBadge>
+            <BaseBadge :label="roleName(role)" size="xl"></BaseBadge>
           </div>
           <ul class="flex-1 min-w-0">
             <AssignmentFinishedModalPerson
@@ -70,6 +70,7 @@ type Props = {
 const props = defineProps<Props>()
 
 const api = useApi()
+const { roleName } = useRoleName()
 
 // A blocked doc's work assignments are closed and held by an active (in_progress)
 // 'blocked' assignment, so adding a new one would create an inconsistent state.

--- a/client/app/components/AssignmentModal.vue
+++ b/client/app/components/AssignmentModal.vue
@@ -4,11 +4,11 @@
       <h1 class="text-xl font-bold pt-4 px-4 py-3">
         <span v-if="props.message.type === 'assign'">
           Assign
-          <BaseBadge :label="props.message.role" size="xl"></BaseBadge>
+          <BaseBadge :label="roleName(props.message.role)" size="xl"></BaseBadge>
         </span>
         <span v-else-if="props.message.type === 'change'">
           Change
-          <BaseBadge :label="props.message.role" size="xl"></BaseBadge>
+          <BaseBadge :label="roleName(props.message.role)" size="xl"></BaseBadge>
           assignment
         </span>
         <span v-else-if="props.message.type === 'add'" class="flex items-center gap-2">
@@ -128,6 +128,8 @@ type Props = {
   defaultRole?: Assignment['role']
 }
 const props = defineProps<Props>()
+
+const { roleName } = useRoleName()
 
 // Exclude the synthetic 'blocked' role from the picker.
 const roleOptions = computed(() => (props.roles ?? []).filter((role) => role.slug !== 'blocked'))

--- a/client/app/components/ClusterReorder.vue
+++ b/client/app/components/ClusterReorder.vue
@@ -60,7 +60,7 @@
                 v-for="assignment in queueItemByDraftName[clusterDocument.name]?.assignmentSet"
                 :key="assignment.id"
                 class="flex items-center gap-1.5 text-sm">
-                <BaseBadge :label="assignment.role" class="shrink-0" />
+                <BaseBadge :label="roleName(assignment.role)" class="shrink-0" />
                 <span class="text-gray-700 dark:text-gray-300 truncate">
                   {{ personById[assignment.person ?? -1]?.name ?? '—' }}
                 </span>
@@ -72,7 +72,7 @@
               v-for="activity in queueItemByDraftName[clusterDocument.name]?.pendingActivities"
               :key="activity.slug"
               class="mr-1">
-              <BaseBadge :label="activity.slug" />
+              <BaseBadge :label="activity.name" />
             </span>
             <span
               v-if="
@@ -152,6 +152,8 @@ const { data: people } = await useAsyncData('rpc-people-for-cluster', () => api.
 })
 
 const personById = computed(() => Object.fromEntries(people.value.map((p) => [p.id, p])))
+
+const { roleName } = useRoleName()
 
 const snackbar = useSnackbar()
 

--- a/client/app/components/DocumentCard.vue
+++ b/client/app/components/DocumentCard.vue
@@ -18,7 +18,7 @@ Based on https://tailwindui.com/components/application-ui/lists/grid-lists#compo
         </div>
       </Anchor>
       <div v-for="role in cookedDocument.needsAssignment">
-        <BaseBadge :label="`Needs ${role?.name ?? '(unnamed)'}`" />
+        <BaseBadge :label="`Needs ${role.name}`" />
       </div>
       <HeadlessMenu as="div" class="relative ml-auto">
         <HeadlessMenuButton class="-m-2.5 block p-2.5 text-gray-400 hover:text-gray-500">

--- a/client/app/components/DocumentCard.vue
+++ b/client/app/components/DocumentCard.vue
@@ -18,7 +18,7 @@ Based on https://tailwindui.com/components/application-ui/lists/grid-lists#compo
         </div>
       </Anchor>
       <div v-for="role in cookedDocument.needsAssignment">
-        <BaseBadge :label="`Needs ${role ?? '(unnamed)'}`" />
+        <BaseBadge :label="`Needs ${role?.name ?? '(unnamed)'}`" />
       </div>
       <HeadlessMenu as="div" class="relative ml-auto">
         <HeadlessMenuButton class="-m-2.5 block p-2.5 text-gray-400 hover:text-gray-500">

--- a/client/app/components/DocumentDependencies.vue
+++ b/client/app/components/DocumentDependencies.vue
@@ -49,6 +49,8 @@ const relatedDocuments = defineModel<RpcRelatedDocumentAsObject[]>({
   default: [] as RpcRelatedDocumentAsObject[]
 })
 
+const { roleName } = useRoleName()
+
 const columns: Column[] = [
   {
     key: 'relationship',
@@ -90,7 +92,7 @@ const columns: Column[] = [
         const person = (people.value || []).find((p: any) => p.id === assignment.person)
         nodes.push(
           h('span', [
-            h(BaseBadge, { label: assignment.role }),
+            h(BaseBadge, { label: roleName(assignment.role) }),
             ' ',
             person ? `(${person.name})` : ''
           ])

--- a/client/app/components/WorkloadSummary.vue
+++ b/client/app/components/WorkloadSummary.vue
@@ -6,7 +6,7 @@
   </component>
   <component :is="elementName" v-for="([role, pageCount], index) in orderedRoles">
     {{ pageCount }}
-    <BaseBadge :label="role" />
+    <BaseBadge :label="roleName(role)" />
     <template v-if="pageCount === 1">page</template>
     <template v-else>pages</template>
     <template v-if="index === orderedRoles.length - 1">.</template>
@@ -26,6 +26,8 @@ type Props = {
 }
 
 const props = withDefaults(defineProps<Props>(), { mode: 'inline' })
+
+const { roleName } = useRoleName()
 
 const elementName = computed(() => (props.mode === 'inline' ? 'span' : 'div'))
 

--- a/client/app/composables/useRoleName.ts
+++ b/client/app/composables/useRoleName.ts
@@ -1,0 +1,18 @@
+import type { RpcRole } from '~/purple_client'
+
+/**
+ * Resolve RpcRole slugs to their display names. Assignment roles are exposed as
+ * slugs throughout the API; this maps them to human-readable names, falling back
+ * to the slug for anything not in the roles list (e.g. the synthetic 'blocked').
+ * useAsyncData's shared key dedupes the fetch across all callers.
+ */
+export const useRoleName = () => {
+  const api = useApi()
+  const { data: roles } = useAsyncData('rpc-roles', () => api.rpcRolesList(), {
+    server: false,
+    lazy: true,
+    default: () => [] as RpcRole[]
+  })
+  const roleName = (slug: string) => roles.value.find((r) => r.slug === slug)?.name ?? slug
+  return { roles, roleName }
+}

--- a/client/app/pages/docs/[id]/assignments.vue
+++ b/client/app/pages/docs/[id]/assignments.vue
@@ -40,7 +40,7 @@
                     /></Anchor>
                   </dt>
                   <dd class="relative">
-                    <BaseBadge :label="assignment.role" />
+                    <BaseBadge :label="roleName(assignment.role)" />
                     <AssignmentState :state="assignment.state" />
                     <template
                       v-if="
@@ -76,7 +76,7 @@
                   :key="pendingAct.slug"
                   class="py-1 grid grid-cols-2">
                   <dd class="relative">
-                    <BaseBadge :label="pendingAct.slug" />
+                    <BaseBadge :label="pendingAct.name" />
                   </dd>
                 </div>
               </dl>
@@ -107,6 +107,7 @@ const route = useRoute()
 const api = useApi()
 const snackbar = useSnackbar()
 const { openOverlayModal } = inject(overlayModalKey)!
+const { roleName } = useRoleName()
 
 // COMPUTED
 

--- a/client/app/pages/docs/[id]/timeline.vue
+++ b/client/app/pages/docs/[id]/timeline.vue
@@ -67,7 +67,7 @@
           <tbody class="divide-y divide-gray-200 dark:divide-neutral-800">
             <tr v-for="row in trackRows" :key="row.key">
               <td class="py-2 pl-4 pr-3">
-                <BaseBadge :label="row.role" />
+                <BaseBadge :label="roleName(row.role)" />
                 <span v-if="row.awaiting" class="ml-2 text-xs opacity-60">awaiting ref</span>
               </td>
               <td class="px-3 py-2">{{ row.person ?? '—' }}</td>
@@ -134,6 +134,7 @@ import {
 
 const route = useRoute()
 const api = useApi()
+const { roleName } = useRoleName()
 
 const currentTab: DocTabId = 'timeline'
 const draftName = computed(() => route.params.id?.toString() ?? '')

--- a/client/app/pages/queue/queue.vue
+++ b/client/app/pages/queue/queue.vue
@@ -40,7 +40,7 @@
             <select v-model="selectedRoleFilter" :class="SELECT_STYLE">
               <option :value="null">All Roles</option>
               <option v-for="role in allRoles" :key="role" :value="role">
-                {{ role }}
+                {{ roleName(role) }}
               </option>
             </select>
           </div>
@@ -54,7 +54,7 @@
             <select v-model="selectedPendingRoleFilter" :class="SELECT_STYLE">
               <option :value="null">All Roles</option>
               <option v-for="role in allPendingRoles" :key="role" :value="role">
-                {{ role }}
+                {{ roleName(role) }}
               </option>
             </select>
           </div>
@@ -193,6 +193,8 @@ const { data: ianaStatuses } = await useAsyncData('iana-statuses', () => api.ian
   lazy: true,
   default: () => [] as IanaStatus[]
 })
+
+const { roleName } = useRoleName()
 
 const needsAssignmentTristate = ref<TristateValue>(TRISTATE_MIXED)
 const hasExceptionTristate = ref<TristateValue>(TRISTATE_MIXED)
@@ -346,7 +348,7 @@ const columns = [
 
         listItems.push(
           h('li', { class: 'flex gap-3' }, [
-            h('span', h(BaseBadge, { label: role, class: 'mr-1' })),
+            h('span', h(BaseBadge, { label: roleName(role), class: 'mr-1' })),
             h(
               'ul',
               { class: 'flex flex-col gap-2' },
@@ -464,7 +466,7 @@ const columns = [
         { class: 'flex flex-col gap-3' },
         value.map((rpcRole) =>
           h('li', { class: 'flex flex-row gap-2' }, [
-            h('div', h(BaseBadge, { label: rpcRole.slug })),
+            h('div', h(BaseBadge, { label: rpcRole.name })),
             !isBlocked &&
               h(
                 'div',

--- a/client/app/pages/team/[id].vue
+++ b/client/app/pages/team/[id].vue
@@ -263,18 +263,19 @@ const { data: allLabels } = await useAsyncData('labels', () => api.labelsList(),
   default: () => [] as Label[]
 })
 
-const ROLES = [
-  { slug: 'enqueuer', label: 'Enqueuer' },
-  { slug: 'ref_checker', label: 'Ref Checker' },
-  { slug: 'formatting', label: 'Formatting' },
-  { slug: 'first_editor', label: 'First Edit' },
-  { slug: 'second_editor', label: 'Second Edit' },
-  { slug: 'final_review_editor', label: 'Final Review' },
-  { slug: 'publisher', label: 'Publisher' }
+// Canonical role order for sorting
+const ROLE_ORDER = [
+  'enqueuer',
+  'ref_checker',
+  'formatting',
+  'first_editor',
+  'second_editor',
+  'final_review_editor',
+  'publisher'
 ]
 
-const roleLabel = (slug: string) => ROLES.find((r) => r.slug === slug)?.label ?? slug
-const roleOrder = (slug: string) => ROLES.findIndex((r) => r.slug === slug)
+const { roleName } = useRoleName()
+const roleOrder = (slug: string) => ROLE_ORDER.indexOf(slug)
 
 // For a blocked assignment, find its current workflow stage from the document's
 // pending activities
@@ -295,10 +296,10 @@ const sortedAssignments = computed(() => {
     if (a.role === 'blocked') {
       // Sort immediately after the inferred stage, or to the very end if unknown.
       const stage = blockedStage(a)
-      return stage ? stage.index + 0.5 : ROLES.length + 1
+      return stage ? stage.index + 0.5 : ROLE_ORDER.length + 1
     }
     const idx = roleOrder(a.role)
-    return idx === -1 ? ROLES.length : idx
+    return idx === -1 ? ROLE_ORDER.length : idx
   }
 
   return [...assignments.value].sort((a, b) => {
@@ -384,7 +385,7 @@ const assignmentColumns = [
     cell: ({ row }) => {
       const a = row.original
       const displayRole = assignmentDisplayRole(a)
-      const label = roleLabel(displayRole)
+      const label = roleName(displayRole)
       const isBlocked = a.role === 'blocked'
       return h(
         'span',


### PR DESCRIPTION
relates to the work in https://github.com/ietf-tools/purple/pull/1421

for assignment roles, display names, not slugs