### PR TITLE
feat: improve behavior blocking refs

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -502,6 +502,60 @@ def submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
     return Response(SubmissionSerializer(subm).data)
 
 
+def upgrade_references_to_rfctobe(rfctobe):
+    """Adopt references that were waiting on rfctobe's draft as a bare Document.
+
+    not-received 1G refs become refqueue and are re-linked to the new RfcToBe (so
+    the blocking gates, which key off target_rfctobe, can see them); not-received
+    2G/3G refs are deleted. Returns the upgraded source drafts, their datatracker
+    ids, and the source ids whose 2G references need recomputation.
+    """
+    recompute_source_ids: set[int] = set()
+    upgraded_source_docs: list[Document] = []
+    upgraded_source_datatracker_ids: set[int] = set()
+    refqueue_rel = DocRelationshipName.objects.get(
+        slug=DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG
+    )
+    existing_references = RpcRelatedDocument.objects.filter(
+        target_document__name=rfctobe.draft.name,
+        relationship__slug__in=DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUGS,
+    ).select_related("source__draft")
+    for existing_reference in existing_references:
+        if (
+            existing_reference.relationship.slug
+            == DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG
+        ):
+            duplicate = (
+                RpcRelatedDocument.objects.filter(
+                    source=existing_reference.source,
+                    target_rfctobe=rfctobe,
+                    relationship=refqueue_rel,
+                )
+                .exclude(pk=existing_reference.pk)
+                .exists()
+            )
+            if duplicate:
+                existing_reference.delete()
+                continue
+            existing_reference.relationship = refqueue_rel
+            existing_reference.target_document = None
+            existing_reference.target_rfctobe = rfctobe
+            existing_reference.save()
+            source_draft = existing_reference.source.draft
+            upgraded_source_docs.append(source_draft)
+            if source_draft.datatracker_id is not None:
+                upgraded_source_datatracker_ids.add(source_draft.datatracker_id)
+        else:
+            if (
+                existing_reference.relationship.slug
+                == DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG
+            ):
+                # schedule recomputation to clean up deleted 2G references.
+                recompute_source_ids.add(existing_reference.source_id)
+            existing_reference.delete()
+    return upgraded_source_docs, upgraded_source_datatracker_ids, recompute_source_ids
+
+
 @extend_schema(
     operation_id="submissions_import",
     request=CreateRfcToBeSerializer,
@@ -561,39 +615,12 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
         with transaction.atomic():
             rfctobe = serializer.save()
 
-            # check for existing references where the new draft is the target
-            # if "not-received" references exist, change them to "refqueue"
-            # if "not-received-2/3g" references exist, delete them
-            recompute_source_ids: set[int] = set()
-            upgraded_source_docs: list[Document] = []
-            upgraded_source_datatracker_ids: set[int] = set()
-            existing_references = RpcRelatedDocument.objects.filter(
-                target_document__name=rfctobe.draft.name,
-                relationship__slug__in=(
-                    DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUGS
-                ),
-            ).select_related("source__draft")
-            for existing_reference in existing_references:
-                if (
-                    existing_reference.relationship.slug
-                    == DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG
-                ):
-                    existing_reference.relationship = DocRelationshipName.objects.get(
-                        slug=DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG
-                    )
-                    existing_reference.save()
-                    source_draft = existing_reference.source.draft
-                    upgraded_source_docs.append(source_draft)
-                    if source_draft.datatracker_id is not None:
-                        upgraded_source_datatracker_ids.add(source_draft.datatracker_id)
-                else:
-                    if (
-                        existing_reference.relationship.slug
-                        == DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG
-                    ):
-                        # schedule recomputation to clean up deleted 2G references.
-                        recompute_source_ids.add(existing_reference.source_id)
-                    existing_reference.delete()
+            # Adopt references that were waiting on this draft as a bare Document.
+            (
+                upgraded_source_docs,
+                upgraded_source_datatracker_ids,
+                recompute_source_ids,
+            ) = upgrade_references_to_rfctobe(rfctobe)
 
             if upgraded_source_docs:
                 apply_submission_cluster_membership(

--- a/rpc/lifecycle/blocked_assignments.py
+++ b/rpc/lifecycle/blocked_assignments.py
@@ -97,6 +97,7 @@ def get_block_reasons(rfc: RfcToBe) -> set[str]:
             for ref in refqueue_qs:
                 target = ref.target_rfctobe
                 if (
+                    # Not in the queue, so not published.
                     target is None
                     or target.incomplete_activities()
                     .filter(slug="first_editor")

--- a/rpc/lifecycle/blocked_assignments.py
+++ b/rpc/lifecycle/blocked_assignments.py
@@ -95,8 +95,10 @@ def get_block_reasons(rfc: RfcToBe) -> set[str]:
         refqueue_qs = rfc.rpcrelateddocument_set.filter(relationship="refqueue")
         if refqueue_qs.exists():
             for ref in refqueue_qs:
+                target = ref.target_rfctobe
                 if (
-                    ref.target_rfctobe.incomplete_activities()
+                    target is None
+                    or target.incomplete_activities()
                     .filter(slug="first_editor")
                     .exists()
                 ):
@@ -119,10 +121,13 @@ def get_block_reasons(rfc: RfcToBe) -> set[str]:
         refqueue_qs = rfc.rpcrelateddocument_set.filter(relationship="refqueue")
         if refqueue_qs.exists():
             for ref in refqueue_qs:
+                target = ref.target_rfctobe
+                if target is None:
+                    # Not in the queue, so not published.
+                    reasons.add(BlockingReason.REFQUEUE_PUBLISH_INCOMPLETE)
+                    continue
                 # block if publisher has no done or active assignment
-                publisher_qs = ref.target_rfctobe.assignment_set.filter(
-                    role__slug="publisher"
-                )
+                publisher_qs = target.assignment_set.filter(role__slug="publisher")
                 publisher_done_or_active = (
                     publisher_qs.active()
                     | publisher_qs.filter(state=Assignment.State.DONE)

--- a/rpc/migrations/0015_backfill_refqueue_target_rfctobe.py
+++ b/rpc/migrations/0015_backfill_refqueue_target_rfctobe.py
@@ -1,0 +1,82 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations
+from django.utils import timezone
+
+CHANGE_REASON = "backfill: link refqueue target to RfcToBe (migration 0015)"
+
+
+def _write_history(Historical, ref, history_type):
+    """Record a simple-history snapshot for a row this migration mutated.
+
+    Migrations bypass simple-history's signals, so without this the next in-app
+    save would diff against the pre-migration snapshot and misattribute this
+    change to that editor. Attributed to no user, tagged with a change reason.
+    """
+    Historical.objects.create(
+        id=ref.pk,
+        relationship_id=ref.relationship_id,
+        source_id=ref.source_id,
+        target_document_id=ref.target_document_id,
+        target_rfctobe_id=ref.target_rfctobe_id,
+        history_date=timezone.now(),
+        history_type=history_type,
+        history_change_reason=CHANGE_REASON,
+        history_user_id=None,
+    )
+
+
+def backfill_refqueue_targets(apps, schema_editor):
+    """Re-link refqueue references from target_document to target_rfctobe.
+
+    A refqueue row created before its target entered the queue points at the
+    datatracker Document. Once the target has an RfcToBe, the blocking gates and
+    the signal-driven re-evaluation both key off target_rfctobe, so such rows are
+    invisible to them. Convert each to point at the active RfcToBe (exactly one
+    target may be set, so target_document is cleared). Drop rows that would
+    duplicate an existing target_rfctobe reference.
+    """
+    RpcRelatedDocument = apps.get_model("rpc", "RpcRelatedDocument")
+    Historical = apps.get_model("rpc", "HistoricalRpcRelatedDocument")
+    RfcToBe = apps.get_model("rpc", "RfcToBe")
+
+    stale = RpcRelatedDocument.objects.filter(
+        relationship_id="refqueue",
+        target_rfctobe__isnull=True,
+        target_document__isnull=False,
+    )
+    for ref in stale:
+        rfctobe = (
+            RfcToBe.objects.filter(draft=ref.target_document)
+            .exclude(disposition_id="withdrawn")
+            .first()
+        )
+        if rfctobe is None:
+            continue  # genuinely external / not in the queue
+        duplicate = (
+            RpcRelatedDocument.objects.filter(
+                source=ref.source,
+                target_rfctobe=rfctobe,
+                relationship_id="refqueue",
+            )
+            .exclude(pk=ref.pk)
+            .exists()
+        )
+        if duplicate:
+            _write_history(Historical, ref, "-")  # snapshot pre-delete state
+            ref.delete()
+            continue
+        ref.target_document = None
+        ref.target_rfctobe = rfctobe
+        ref.save(update_fields=["target_document", "target_rfctobe"])
+        _write_history(Historical, ref, "~")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rpc", "0014_backfill_rev_into_history"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_refqueue_targets, migrations.RunPython.noop),
+    ]

--- a/rpc/migrations/0015_backfill_refqueue_target_rfctobe.py
+++ b/rpc/migrations/0015_backfill_refqueue_target_rfctobe.py
@@ -37,7 +37,7 @@ def backfill_refqueue_targets(apps, schema_editor):
     duplicate an existing target_rfctobe reference.
     """
     RpcRelatedDocument = apps.get_model("rpc", "RpcRelatedDocument")
-    Historical = apps.get_model("rpc", "HistoricalRpcRelatedDocument")
+    HistoricalRpcRelatedDocument = apps.get_model("rpc", "HistoricalRpcRelatedDocument")
     RfcToBe = apps.get_model("rpc", "RfcToBe")
 
     stale = RpcRelatedDocument.objects.filter(
@@ -63,13 +63,15 @@ def backfill_refqueue_targets(apps, schema_editor):
             .exists()
         )
         if duplicate:
-            _write_history(Historical, ref, "-")  # snapshot pre-delete state
+            _write_history(
+                HistoricalRpcRelatedDocument, ref, "-"
+            )  # snapshot pre-delete state
             ref.delete()
             continue
         ref.target_document = None
         ref.target_rfctobe = rfctobe
         ref.save(update_fields=["target_document", "target_rfctobe"])
-        _write_history(Historical, ref, "~")
+        _write_history(HistoricalRpcRelatedDocument, ref, "~")
 
 
 class Migration(migrations.Migration):

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -13,10 +13,11 @@ from rest_framework.exceptions import NotFound
 
 from datatracker.factories import DocumentFactory
 from datatracker.models import Document
-from rpc.models import Cluster, ClusterMember, DocRelationshipName, RpcRelatedDocument
 from rpc.models import (
     Assignment,
     BlockingReason,
+    Cluster,
+    ClusterMember,
     DocRelationshipName,
     RpcRelatedDocument,
     RpcRole,

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -14,9 +14,18 @@ from rest_framework.exceptions import NotFound
 from datatracker.factories import DocumentFactory
 from datatracker.models import Document
 from rpc.models import Cluster, ClusterMember, DocRelationshipName, RpcRelatedDocument
+from rpc.models import (
+    Assignment,
+    BlockingReason,
+    DocRelationshipName,
+    RpcRelatedDocument,
+    RpcRole,
+)
 
 from .api import apply_submission_cluster_membership, resolve_rfctobe
+from .lifecycle.blocked_assignments import get_block_reasons
 from .factories import (
+    AssignmentFactory,
     ClusterFactory,
     DispositionNameFactory,
     RfcToBeFactory,
@@ -440,6 +449,163 @@ class DocumentSearchTests(TestCase):
         self.assertEqual(len(payload["results"]), 1)
         self.assertEqual(payload["results"][0]["id"], in_progress.id)
         self.assertEqual(payload["results"][0]["disposition"]["slug"], "in_progress")
+
+
+class RefqueueBlockingTests(TestCase):
+    """Refqueue references: how they block the citing doc, and how import links them.
+
+    A refqueue ref that doesn't resolve to a queued RfcToBe (target_rfctobe is null)
+    blocks the citing doc; import links not-received refs to the new RfcToBe.
+    """
+
+    def _role(self, slug):
+        role, _ = RpcRole.objects.get_or_create(slug=slug, defaults={"name": slug})
+        return role
+
+    def _done(self, rfc, slug):
+        AssignmentFactory(
+            rfc_to_be=rfc, role=self._role(slug), state=Assignment.State.DONE
+        )
+
+    def _source_at_second_edit(self):
+        """An RfcToBe whose first edit is finished and second edit is pending."""
+        source = RfcToBeFactory()
+        for slug in ("enqueuer", "formatting", "ref_checker", "first_editor"):
+            self._done(source, slug)
+        return source
+
+    def _refqueue(self):
+        rel, _ = DocRelationshipName.objects.get_or_create(
+            slug="refqueue", defaults={"name": "refqueue"}
+        )
+        return rel
+
+    def test_blocks_when_normref_first_edit_incomplete(self):
+        source = self._source_at_second_edit()
+        target = RfcToBeFactory()
+        AssignmentFactory(
+            rfc_to_be=target,
+            role=self._role("first_editor"),
+            state=Assignment.State.IN_PROGRESS,
+        )
+        RpcRelatedDocument.objects.create(
+            source=source, relationship=self._refqueue(), target_rfctobe=target
+        )
+
+        reasons = get_block_reasons(source)
+
+        self.assertIn(BlockingReason.REFQUEUE_FIRST_EDIT_INCOMPLETE, reasons)
+
+    def test_no_block_when_normref_first_edit_done(self):
+        source = self._source_at_second_edit()
+        target = RfcToBeFactory()
+        self._done(target, "first_editor")
+        RpcRelatedDocument.objects.create(
+            source=source, relationship=self._refqueue(), target_rfctobe=target
+        )
+
+        reasons = get_block_reasons(source)
+
+        self.assertNotIn(BlockingReason.REFQUEUE_FIRST_EDIT_INCOMPLETE, reasons)
+
+    def test_unqueued_ref_blocks_second_edit(self):
+        source = self._source_at_second_edit()
+        unqueued = DocumentFactory(  # a normref not in the queue (no RfcToBe)
+            name="draft-unqueued-normref", pages=10
+        )
+        RpcRelatedDocument.objects.create(
+            source=source,
+            relationship=self._refqueue(),
+            target_document=unqueued,
+        )
+
+        reasons = get_block_reasons(source)
+
+        self.assertIn(BlockingReason.REFQUEUE_FIRST_EDIT_INCOMPLETE, reasons)
+
+    def test_unqueued_ref_blocks_publish(self):
+        source = RfcToBeFactory()
+        for slug in (
+            "enqueuer",
+            "formatting",
+            "ref_checker",
+            "first_editor",
+            "second_editor",
+            "final_review_editor",
+        ):
+            self._done(source, slug)  # reach the publisher gate
+        unqueued = DocumentFactory(name="draft-unqueued-pubref", pages=10)
+        RpcRelatedDocument.objects.create(
+            source=source, relationship=self._refqueue(), target_document=unqueued
+        )
+
+        reasons = get_block_reasons(source)
+
+        self.assertIn(BlockingReason.REFQUEUE_PUBLISH_INCOMPLETE, reasons)
+
+    def _not_received(self):
+        rel, _ = DocRelationshipName.objects.get_or_create(
+            slug="not-received", defaults={"name": "not-received"}
+        )
+        return rel
+
+    def test_upgrade_references_relinks_not_received_to_refqueue(self):
+        from rpc.api import upgrade_references_to_rfctobe
+
+        self._refqueue()  # ensure the refqueue relationship exists
+        source = RfcToBeFactory()
+        target_doc = DocumentFactory(name="draft-becomes-queued", pages=5)
+        ref = RpcRelatedDocument.objects.create(
+            source=source, relationship=self._not_received(), target_document=target_doc
+        )
+        target = RfcToBeFactory(draft=target_doc)  # the draft enters the queue
+
+        upgrade_references_to_rfctobe(target)
+
+        ref.refresh_from_db()
+        self.assertEqual(ref.relationship_id, "refqueue")
+        self.assertEqual(ref.target_rfctobe_id, target.pk)
+        self.assertIsNone(ref.target_document_id)
+
+    def test_upgrade_references_drops_duplicate(self):
+        from rpc.api import upgrade_references_to_rfctobe
+
+        rel = self._refqueue()
+        source = RfcToBeFactory()
+        target_doc = DocumentFactory(name="draft-dup-queued", pages=5)
+        target = RfcToBeFactory(draft=target_doc)
+        RpcRelatedDocument.objects.create(
+            source=source, relationship=rel, target_rfctobe=target
+        )
+        stale = RpcRelatedDocument.objects.create(
+            source=source, relationship=self._not_received(), target_document=target_doc
+        )
+
+        upgrade_references_to_rfctobe(target)
+
+        self.assertFalse(RpcRelatedDocument.objects.filter(pk=stale.pk).exists())
+
+    def test_backfill_migration_writes_history_snapshot(self):
+        """The migration's filler must record its change in simple-history so a
+        later edit's diff can't absorb it and misattribute it (migrations bypass
+        simple-history's signals)."""
+        from importlib import import_module
+
+        mod = import_module("rpc.migrations.0015_backfill_refqueue_target_rfctobe")
+        ref = RpcRelatedDocument.objects.create(
+            source=RfcToBeFactory(),
+            relationship=self._refqueue(),
+            target_rfctobe=RfcToBeFactory(),
+        )
+        historical = RpcRelatedDocument.history.model
+
+        mod._write_history(historical, ref, "~")
+
+        snap = historical.objects.filter(id=ref.pk).order_by("-history_date").first()
+        self.assertEqual(snap.history_type, "~")
+        self.assertEqual(snap.target_rfctobe_id, ref.target_rfctobe_id)
+        self.assertIsNone(snap.history_user_id)
+        self.assertEqual(snap.history_change_reason, mod.CHANGE_REASON)
 
 
 class ClusterIsActiveTests(TestCase):

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -23,7 +23,6 @@ from rpc.models import (
 )
 
 from .api import apply_submission_cluster_membership, resolve_rfctobe
-from .lifecycle.blocked_assignments import get_block_reasons
 from .factories import (
     AssignmentFactory,
     ClusterFactory,
@@ -35,6 +34,7 @@ from .factories import (
     TlpBoilerplateChoiceNameFactory,
     UnusableRfcNumberFactory,
 )
+from .lifecycle.blocked_assignments import get_block_reasons
 from .utils import next_rfc_number
 
 # Minimal data that rpcapi_client.FullDraft.from_json() accepts


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1477

Problem:
A normative ("refqueue") reference created before its target entered the queue points at the datatracker Document, with target_rfctobe null. The second-edit and publish gates dereferenced target_rfctobe unconditionally, so such a reference raised AttributeError and aborted block evaluation — leaving the citing document silently unblocked. The import flow also flipped the relation type not-received → refqueue without re-linking the target, which is what produced those rows in the first place.

Changes:
- re-link reference from DT-document to the newly created RfcToBe at import
- a refqueue reference that doesn't resolve to a queued RfcToBe now blocks the citing doc (REFQUEUE_FIRST_EDIT_INCOMPLETE / REFQUEUE_PUBLISH_INCOMPLETE) instead of crashing — "not in the queue" is treated as "not ready".
- Backfill (0015_backfill_refqueue_target_rfctobe): re-links existing stale rows, and writes simple-history snapshots for each change so it isn't later misattributed to the next editor (migrations bypass simple-history otherwise).
- add tests