### PR TITLE
feat: cluster with only one doc is inactive

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -960,8 +960,8 @@ class CapabilityViewSet(viewsets.ReadOnlyModelViewSet):
 class ClusterFilter(django_filters.FilterSet):
     is_active = django_filters.BooleanFilter(
         field_name="is_active_annotated",
-        help_text="Filter by active status. A cluster is considered active if at least "
-        "one of its documents is not in terminal state (published/withdrawn).",
+        help_text="Filter by active status. A cluster is considered active if more "
+        "than one of its documents is not in terminal state (published/withdrawn).",
     )
 
     class Meta:

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -12,10 +12,15 @@ from django.contrib.postgres.forms import SimpleArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import (
-    Exists,
+    BooleanField,
+    Case,
+    Count,
     OuterRef,
     Prefetch,
+    Q,
     Subquery,
+    Value,
+    When,
 )
 from django.utils import timezone
 from rules import always_deny
@@ -751,15 +756,27 @@ class ClusterQuerySet(models.QuerySet):
         )
 
     def with_is_active_annotated(self):
-        """Annotate clusters with is_active status
-        A cluster is considered active if at least one of its documents is in_progress.
+        """Annotate clusters with is_active status.
+
+        Active only while more than one document is still unpublished (not in a
+        terminal published/withdrawn state) — a lone remaining doc has nothing
+        left to coordinate with.
         """
         return self.annotate(
-            is_active_annotated=Exists(
-                RfcToBe.objects.filter(
-                    draft__clustermember__cluster=OuterRef("pk"),
-                    disposition__slug="in_progress",
-                )
+            _unpublished_count=Count(
+                "clustermember__doc__rfctobe",
+                filter=Q(
+                    clustermember__doc__rfctobe__disposition__slug__in=(
+                        DispositionName.ACTIVE_SLUGS
+                    )
+                ),
+                distinct=True,
+            ),
+        ).annotate(
+            is_active_annotated=Case(
+                When(_unpublished_count__gt=1, then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
             )
         )
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -2052,17 +2052,19 @@ class ClusterSerializer(serializers.ModelSerializer):
         fields = ["number", "documents", "draft_names", "is_active"]
 
     def get_is_active(self, cluster) -> bool:
-        """A cluster is considered active if at least one of its documents is
-        in_progress."""
+        """Active only while more than one document is still unpublished."""
 
         # Use annotated value if available
         if hasattr(cluster, "is_active_annotated"):
             return cluster.is_active_annotated
 
-        return RfcToBe.objects.filter(
-            draft__clustermember__cluster=cluster,
-            disposition__slug="in_progress",
-        ).exists()
+        return (
+            RfcToBe.objects.filter(
+                draft__clustermember__cluster=cluster,
+                disposition__slug__in=DispositionName.ACTIVE_SLUGS,
+            ).count()
+            > 1
+        )
 
     def create(self, validated_data):
         draft_names = validated_data.pop("draft_names", [])

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import NotFound
 
 from datatracker.factories import DocumentFactory
 from datatracker.models import Document
-from rpc.models import DocRelationshipName, RpcRelatedDocument
+from rpc.models import Cluster, ClusterMember, DocRelationshipName, RpcRelatedDocument
 
 from .api import apply_submission_cluster_membership, resolve_rfctobe
 from .factories import (
@@ -440,3 +440,43 @@ class DocumentSearchTests(TestCase):
         self.assertEqual(len(payload["results"]), 1)
         self.assertEqual(payload["results"][0]["id"], in_progress.id)
         self.assertEqual(payload["results"][0]["disposition"]["slug"], "in_progress")
+
+
+class ClusterIsActiveTests(TestCase):
+    """A cluster is active only while more than one document is still unpublished."""
+
+    def _add(self, cluster, disposition_slug, order):
+        rtb = RfcToBeFactory(disposition=DispositionNameFactory(slug=disposition_slug))
+        ClusterMember.objects.create(cluster=cluster, doc=rtb.draft, order=order)
+        return rtb
+
+    def _is_active(self, cluster):
+        annotated = Cluster.objects.with_is_active_annotated().get(pk=cluster.pk)
+        return annotated.is_active_annotated
+
+    def test_two_unpublished_is_active(self):
+        cluster = ClusterFactory()
+        self._add(cluster, "in_progress", 1)
+        self._add(cluster, "in_progress", 2)
+        self.assertTrue(self._is_active(cluster))
+
+    def test_single_unpublished_with_published_is_inactive(self):
+        cluster = ClusterFactory()
+        self._add(cluster, "in_progress", 1)
+        self._add(cluster, "published", 2)
+        self.assertFalse(self._is_active(cluster))
+
+    def test_all_published_is_inactive(self):
+        cluster = ClusterFactory()
+        self._add(cluster, "published", 1)
+        self._add(cluster, "published", 2)
+        self.assertFalse(self._is_active(cluster))
+
+    def test_serializer_fallback_matches_annotation(self):
+        from rpc.serializers import ClusterSerializer
+
+        cluster = ClusterFactory()
+        self._add(cluster, "in_progress", 1)
+        self._add(cluster, "published", 2)
+        # A plain instance has no annotation, exercising the fallback query.
+        self.assertFalse(ClusterSerializer().get_is_active(cluster))


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1481

if only one doc remains, we consider it inactive