### PR TITLE
feat: make labels case insensitive in context for email templates

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -2647,7 +2647,9 @@ class RfcMailTemplatesList(views.APIView):
         rfc_number = rfc_to_be.rfc_number or "XXXX"
 
         # Pick the final review template and subject based on the draft's labels.
-        label_slugs = set(rfc_to_be.labels.values_list("slug", flat=True))
+        label_slugs = {
+            slug.lower() for slug in rfc_to_be.labels.values_list("slug", flat=True)
+        }
         has_markdown = "markdown" in label_slugs
         has_github = "github" in label_slugs
         if has_markdown and has_github:


### PR DESCRIPTION
short term fix for https://github.com/ietf-tools/purple/issues/1479#issuecomment-5427127323 to allow to rename labels 
- github -> Github
- markdown -> Markdown

The real/longterm fix is to introduce a concept of slug/name for labels, which will be addressed in https://github.com/ietf-tools/purple/issues/1486