### PR TITLE
fix: inactive clusters pubq error

### DIFF
--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -262,8 +262,8 @@ paths:
           name: is_active
           schema:
             type: boolean
-          description: Filter by active status. A cluster is considered active if at
-            least one of its documents is not in terminal state (published/withdrawn).
+          description: Filter by active status. A cluster is considered active if more
+            than one of its documents is not in terminal state (published/withdrawn).
         - name: ordering
           required: false
           in: query
@@ -3890,9 +3890,7 @@ components:
           readOnly: true
         is_active:
           type: boolean
-          description: |-
-            A cluster is considered active if at least one of its documents is
-            in_progress.
+          description: Active only while more than one document is still unpublished.
           readOnly: true
       required:
         - number
@@ -5359,9 +5357,7 @@ components:
           readOnly: true
         is_active:
           type: boolean
-          description: |-
-            A cluster is considered active if at least one of its documents is
-            in_progress.
+          description: Active only while more than one document is still unpublished.
           readOnly: true
       required:
         - number
@@ -5453,6 +5449,7 @@ components:
         cluster:
           allOf:
             - $ref: "#/components/schemas/SimpleCluster"
+          nullable: true
           readOnly: true
         assignment_set:
           type: array

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -5772,6 +5772,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/SimpleCluster"
           readOnly: true
+          nullable: true
         assignment_set:
           type: array
           items:
@@ -6024,6 +6025,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/SimpleCluster"
           readOnly: true
+          nullable: true
         submitted_format:
           allOf:
             - $ref: "#/components/schemas/Name"

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -962,6 +962,15 @@ class PublicQueueList(QueueList):
         ),
     )
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["active_cluster_numbers"] = set(
+            Cluster.objects.with_is_active_annotated()
+            .filter(is_active_annotated=True)
+            .values_list("number", flat=True)
+        )
+        return context
+
 
 PublicQueueList = extend_schema_view(
     get=extend_schema(
@@ -1002,11 +1011,16 @@ class PublicClusterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = (
         Cluster.objects.with_data_annotated()
         .with_is_active_annotated()
-        .filter(is_active_annotated=True)
         .order_by("number")
     )
     serializer_class = PublicClusterSerializer
     lookup_field = "number"
+
+    def get_queryset(self):
+        # List advertises only active clusters; retrieve resolves any cluster by
+        # number so a reference from the public queue never 404s.
+        qs = super().get_queryset()
+        return qs.filter(is_active_annotated=True) if self.action == "list" else qs
 
 
 class ClusterViewSet(

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -2618,11 +2618,24 @@ class PublicQueueItemSerializer(QueueItemSerializer):
     )
     # only expose labels flagged public.
     labels = serializers.SerializerMethodField()
+    # only reference the cluster while it's active, matching what
+    # /api/pubq/clusters/ lists (active_cluster_numbers comes from the view).
+    cluster = serializers.SerializerMethodField()
 
     @extend_schema_field(LabelSerializer(many=True))
     def get_labels(self, obj):
         public = [label for label in obj.labels.all() if label.is_public]
         return LabelSerializer(public, many=True).data
+
+    @extend_schema_field(SimpleClusterSerializer(allow_null=True))
+    def get_cluster(self, obj):
+        cluster = obj.cluster
+        if cluster is None:
+            return None
+        active = self.context.get("active_cluster_numbers")
+        if active is not None and cluster.number not in active:
+            return None
+        return SimpleClusterSerializer(cluster).data
 
     @extend_schema_field(RpcRelatedDocumentSerializer(many=True))
     def get_references(self, obj):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -697,7 +697,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
         allow_null=True,  # might be null for an April 1 RFC
     )
     pages = serializers.IntegerField(read_only=True)
-    cluster = SimpleClusterSerializer(read_only=True)
+    cluster = SimpleClusterSerializer(read_only=True, allow_null=True)
     labels = LabelSerializer(many=True, read_only=True)
     assignment_set = AssignmentSerializer(
         source="active_assignments", many=True, read_only=True
@@ -877,7 +877,7 @@ class RfcToBeSerializer(serializers.ModelSerializer):
     """RfcToBeSerializer suitable for displaying full details of a single instance"""
 
     draft = DraftSerializer(read_only=True)
-    cluster = SimpleClusterSerializer(read_only=True)
+    cluster = SimpleClusterSerializer(read_only=True, allow_null=True)
     # Need to explicitly specify labels as a PK because it uses a through model
     labels = serializers.PrimaryKeyRelatedField(many=True, queryset=Label.objects.all())
     authors = RfcAuthorSerializer(many=True)

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -647,3 +647,67 @@ class ClusterIsActiveTests(TestCase):
         self._add(cluster, "published", 2)
         # A plain instance has no annotation, exercising the fallback query.
         self.assertFalse(ClusterSerializer().get_is_active(cluster))
+
+
+class PublicClusterConsistencyTests(TestCase):
+    """pubq: the cluster list advertises only active clusters, but a cluster the
+    public queue references is always retrievable (no dangling 404)."""
+
+    def _member(self, cluster, disposition_slug, order):
+        rtb = RfcToBeFactory(disposition=DispositionNameFactory(slug=disposition_slug))
+        ClusterMember.objects.create(cluster=cluster, doc=rtb.draft, order=order)
+        return rtb
+
+    def _active_numbers(self):
+        return set(
+            Cluster.objects.with_is_active_annotated()
+            .filter(is_active_annotated=True)
+            .values_list("number", flat=True)
+        )
+
+    def test_list_active_only_but_retrieve_resolves_any(self):
+        from rpc.api import PublicClusterViewSet
+
+        inactive = ClusterFactory()
+        self._member(inactive, "in_progress", 1)  # lone unpublished -> inactive
+        active = ClusterFactory()
+        self._member(active, "in_progress", 1)
+        self._member(active, "in_progress", 2)
+
+        view = PublicClusterViewSet()
+        view.action = "list"
+        listed = set(view.get_queryset().values_list("number", flat=True))
+        self.assertIn(active.number, listed)
+        self.assertNotIn(inactive.number, listed)
+
+        view.action = "retrieve"
+        self.assertIn(
+            inactive.number, set(view.get_queryset().values_list("number", flat=True))
+        )
+
+    def test_queue_nulls_inactive_cluster_but_keeps_active(self):
+        from rpc.serializers import PublicQueueItemSerializer
+
+        inactive = ClusterFactory()
+        lone = self._member(inactive, "in_progress", 1)  # lone unpublished -> inactive
+        ser = PublicQueueItemSerializer(
+            context={"active_cluster_numbers": self._active_numbers()}
+        )
+        self.assertIsNone(ser.get_cluster(lone))
+
+        active = ClusterFactory()
+        member = self._member(active, "in_progress", 1)
+        self._member(active, "in_progress", 2)
+        ser = PublicQueueItemSerializer(
+            context={"active_cluster_numbers": self._active_numbers()}
+        )
+        self.assertEqual(ser.get_cluster(member), {"number": active.number})
+
+    def test_queue_shows_cluster_without_context(self):
+        from rpc.serializers import PublicQueueItemSerializer
+
+        inactive = ClusterFactory()
+        lone = self._member(inactive, "in_progress", 1)
+        self.assertEqual(
+            PublicQueueItemSerializer().get_cluster(lone), {"number": inactive.number}
+        )


### PR DESCRIPTION
changed for pubq:

- for queue endpoint, return only active clusters
- cluster retrieve endpoint may also return inactive clusters (instead of 404) 

Current behavior: 
queue endpoint returns inactive clusters. Attempts to get details of inactive cluster result in 404

Also: schema cleanup, regenerate fresh schema