### PR TITLE
fix: change legacy label slugs for reports

### DIFF
--- a/client/app/components/RpcLabelEditDialog.vue
+++ b/client/app/components/RpcLabelEditDialog.vue
@@ -269,7 +269,7 @@ const label = reactive<Label>(props.label ? { ...props.label } : NEW_LABEL_DEFAU
 const isNew = computed(() => label.id === undefined)
 const slugEdited = ref(false)
 
-// Mirror the backend slug format: lowercase kebab-case (see migration 0016).
+// Match the slug the backend generates from the name: lowercase kebab-case.
 const toSlug = (value: string) =>
   value
     .toLowerCase()

--- a/rpc/admin.py
+++ b/rpc/admin.py
@@ -157,8 +157,8 @@ class ApprovalLogMessageAdmin(admin.ModelAdmin):
 
 @admin.register(Label)
 class LabelAdmin(admin.ModelAdmin):
-    list_display = ["slug", "is_complexity", "is_exception", "color"]
-    search_fields = ["slug"]
+    list_display = ["slug", "text", "is_complexity", "is_exception", "color"]
+    search_fields = ["slug", "text"]
     list_filter = ["is_complexity", "is_exception", "color"]
 
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1245,11 +1245,18 @@ def _rfctobe_describe_delta(delta: ModelDelta):
             new = set(delta.new_record.labels.values_list("label__pk", flat=True))
             added = new - old
             removed = old - new
-            hist_labels = Label.history.as_of(delta.new_record.history_date)
-            for label in hist_labels.filter(id__in=added):
-                yield f"Label ({label.slug}): Added"
-            for label in hist_labels.filter(id__in=removed):
-                yield f"Label ({label.slug}): Removed"
+            ids = added | removed
+            display = {lbl.id: str(lbl) for lbl in Label.objects.filter(id__in=ids)}
+            # Labels deleted since aren't in the live table; recover their last name.
+            for label_id in ids - display.keys():
+                snapshot = Label.history.filter(id=label_id).first()
+                display[label_id] = (
+                    (snapshot.text or snapshot.slug) if snapshot else f"#{label_id}"
+                )
+            for label_id in added:
+                yield f"Label ({display[label_id]}): Added"
+            for label_id in removed:
+                yield f"Label ({display[label_id]}): Removed"
         elif change.field in _PERSON_FK_FIELDS:
             display_field = change.field.removesuffix("_id")
             old_label = _person_label(change.old)

--- a/rpc/stats/rollups.py
+++ b/rpc/stats/rollups.py
@@ -264,9 +264,9 @@ def queue_rollup(
         """Per-doc ``{category: (is_blocked, merged_intervals)}`` from bulk data.
 
         ``category`` is an assignment role slug (post-transition) or a legacy
-        state label's display text (pre-transition). ``awaiting ref:`` time is carved out of
-        ``final_review_editor`` into a blocked ``awaiting_ref`` category, and — for
-        docs with blocking reasons — the single ``blocked`` category is itemised
+        state label's display text (pre-transition). ``awaiting ref:`` time is carved
+        out of ``final_review_editor`` into a blocked ``awaiting_ref`` category, and —
+        for docs with blocking reasons — the single ``blocked`` category is itemised
         into one blocked category per reason (mirroring the doc timeline). All
         sourced from the bulk lookups above rather than per-doc queries.
         """

--- a/rpc/stats/rollups.py
+++ b/rpc/stats/rollups.py
@@ -242,12 +242,13 @@ def queue_rollup(
     # Bulk-load every per-doc history walk the category build needs, so the
     # rollup runs a handful of queries instead of several per document.
     seg_by_doc = _assignment_segments_by_doc(doc_ids)
-    legacy_slug_by_pk = (
-        dict(
-            Label.objects.filter(slug__in=LEGACY_STATE_LABEL_SLUGS).values_list(
-                "pk", "slug"
-            )
-        )
+    legacy_by_pk = (
+        {
+            pk: (slug, text)
+            for pk, slug, text in Label.objects.filter(
+                slug__in=LEGACY_STATE_LABEL_SLUGS
+            ).values_list("pk", "slug", "text")
+        }
         if include_legacy
         else {}
     )
@@ -256,14 +257,14 @@ def queue_rollup(
             "pk", flat=True
         )
     )
-    label_iv = _label_intervals_by_doc(doc_ids, set(legacy_slug_by_pk) | awaiting_pks)
+    label_iv = _label_intervals_by_doc(doc_ids, set(legacy_by_pk) | awaiting_pks)
     reason_by_doc = _blocked_reason_intervals_by_doc(doc_ids, now)
 
     def _categories(doc_id: int) -> dict[str, tuple[bool, list]]:
         """Per-doc ``{category: (is_blocked, merged_intervals)}`` from bulk data.
 
         ``category`` is an assignment role slug (post-transition) or a legacy
-        state label slug (pre-transition). ``awaiting ref:`` time is carved out of
+        state label's display text (pre-transition). ``awaiting ref:`` time is carved out of
         ``final_review_editor`` into a blocked ``awaiting_ref`` category, and — for
         docs with blocking reasons — the single ``blocked`` category is itemised
         into one blocked category per reason (mirroring the doc timeline). All
@@ -274,13 +275,13 @@ def queue_rollup(
             _b, intervals = raw.setdefault(role_id, (is_blocked, []))
             intervals.extend((start, end) for start, end, _state in runs)
         if doc_id in legacy_ids:
-            for lpk, slug in legacy_slug_by_pk.items():
+            for lpk, (slug, text) in legacy_by_pk.items():
                 is_blocked = slug in LEGACY_BLOCKED_LABEL_SLUGS
                 for start, end in label_iv.get(doc_id, {}).get(lpk, []):
                     clipped = clip(start, end, hi=TRANSITION_DATE)
                     if clipped is None:
                         continue
-                    _b, intervals = raw.setdefault(slug, (is_blocked, []))
+                    _b, intervals = raw.setdefault(text or slug, (is_blocked, []))
                     intervals.append(clipped)
         result = {
             category: (is_blocked, merge_intervals(intervals, now))

--- a/rpc/stats/tests_rollups.py
+++ b/rpc/stats/tests_rollups.py
@@ -177,7 +177,7 @@ class QueueRollupTests(TestCase):
         )
         apply_label_over(
             rfc,
-            LabelFactory(slug="awaiting ref: RFC-to-be 1234"),
+            LabelFactory(slug="awaiting-ref-rfc-to-be-1234"),
             dt(2026, 6, 10),
             dt(2026, 6, 20),
         )
@@ -299,7 +299,7 @@ class QueueRollupTests(TestCase):
         # picked up as a candidate and contribute to the March window.
         rfc = RfcToBeFactory()
         apply_label_over(
-            rfc, LabelFactory(slug="IANA"), dt(2026, 3, 1), dt(2026, 3, 15)
+            rfc, LabelFactory(slug="iana"), dt(2026, 3, 1), dt(2026, 3, 15)
         )
         periods = queue_rollup("month", 6, self.now)
         by_label = {p["label"]: p for p in periods}
@@ -315,14 +315,14 @@ class QueueRollupTests(TestCase):
             published_at=dt(2026, 6, 10),
         )
         apply_label_over(
-            legacy_only, LabelFactory(slug="TI"), dt(2026, 3, 1), dt(2026, 3, 5)
+            legacy_only, LabelFactory(slug="ti"), dt(2026, 3, 1), dt(2026, 3, 5)
         )
         # Excluded: published before the range.
         old_published = self._doc_with_work(disposition_slug="published")
         old_published.published_at = dt(2026, 1, 1)
         old_published.save()
         # Excluded: no assignment, only a non-state (complexity) label.
-        RfcToBeFactory().labels.add(LabelFactory(slug="refs: hard"))
+        RfcToBeFactory().labels.add(LabelFactory(slug="refs-hard"))
 
         ids = set(
             _candidate_docs(earliest, include_legacy=True).values_list("pk", flat=True)
@@ -443,7 +443,7 @@ class QueueCountsRollupTests(TestCase):
         # change-points, so an overlapping second label matters).
         rfc = self._doc(dt(2026, 1, 1))
         a = LabelFactory(slug="missref")
-        b = LabelFactory(slug="AUTH48")
+        b = LabelFactory(slug="auth48")
         apply_label_over(rfc, a, dt(2026, 2, 1), dt(2026, 4, 1))
         apply_label_over(rfc, b, dt(2026, 3, 1), dt(2026, 5, 1))  # overlaps a
         bulk = _label_intervals_by_doc([rfc.pk], {a.pk, b.pk}).get(rfc.pk, {})

--- a/rpc/stats/tests_timeline.py
+++ b/rpc/stats/tests_timeline.py
@@ -89,18 +89,18 @@ class AssignmentTimelineTests(TestCase):
     def test_legacy_state_labels_before_transition(self):
         rfc = RfcToBeFactory()
         # IANA is a recognized blocking legacy state; EDIT is active work.
-        blocking_state = LabelFactory(slug="IANA")
-        working_state = LabelFactory(slug="EDIT")
+        blocking_state = LabelFactory(slug="iana")
+        working_state = LabelFactory(slug="edit")
         # A complexity/type label that must be ignored (not a workflow state).
-        noise = LabelFactory(slug="refs: hard")
+        noise = LabelFactory(slug="refs-hard")
         apply_label_over(rfc, blocking_state, dt(2026, 3, 1), dt(2026, 3, 15))
         apply_label_over(rfc, working_state, dt(2026, 4, 1), dt(2026, 4, 8))
         apply_label_over(rfc, noise, dt(2026, 4, 10), dt(2026, 4, 20))
 
         bands = {b.label: b for b in timeline.legacy_bands(rfc)}
-        assert set(bands) == {"IANA", "EDIT"}  # "refs: hard" ignored
-        assert bands["IANA"].kind == KIND_BLOCKED
-        assert bands["EDIT"].kind == KIND_LEGACY
+        assert set(bands) == {"iana", "edit"}  # "refs-hard" ignored
+        assert bands["iana"].kind == KIND_BLOCKED
+        assert bands["edit"].kind == KIND_LEGACY
 
         blocked, working = document_intervals(rfc, self.now)
         assert (dt(2026, 3, 1), dt(2026, 3, 15)) in blocked
@@ -109,7 +109,7 @@ class AssignmentTimelineTests(TestCase):
     def test_include_legacy_false_skips_labels(self):
         rfc = RfcToBeFactory()
         apply_label_over(
-            rfc, LabelFactory(slug="IANA"), dt(2026, 3, 1), dt(2026, 3, 15)
+            rfc, LabelFactory(slug="iana"), dt(2026, 3, 1), dt(2026, 3, 15)
         )
         blocked, working = document_intervals(rfc, self.now, include_legacy=False)
         assert blocked == []
@@ -184,7 +184,7 @@ class AssignmentTimelineTests(TestCase):
         # "awaiting ref:" label applied for part of the final-review window.
         apply_label_over(
             rfc,
-            LabelFactory(slug="awaiting ref: RFC-to-be 1234"),
+            LabelFactory(slug="awaiting-ref-rfc-to-be-1234"),
             dt(2026, 6, 10),
             dt(2026, 6, 20),
         )

--- a/rpc/stats/timeline.py
+++ b/rpc/stats/timeline.py
@@ -34,32 +34,33 @@ TRANSITION_DATE = datetime.datetime(2026, 5, 20, tzinfo=datetime.UTC)
 # Only these labels are reconstructed on the timeline; every other label
 # (complexity/type/exception classifications) is a persistent attribute, not a
 # time-boxed state.
+# Slugs are lowercase since migration 0016 re-slugged all labels (slugify).
 LEGACY_STATE_LABEL_SLUGS = frozenset(
     {
-        "EDIT",
-        "REF",
-        "RFC-EDITOR",
-        "TI",
-        "AUTH48-DONE",
-        "PENDING",
-        "AUTH",
-        "AUTH48",
-        "IESG",
-        "MISSREF",
-        "IANA",
+        "edit",
+        "ref",
+        "rfc-editor",
+        "ti",
+        "auth48-done",
+        "pending",
+        "auth",
+        "auth48",
+        "iesg",
+        "missref",
+        "iana",
     }
 )
 
 # The subset of old-editor states that count as "blocked". The remaining
-# legacy states (EDIT, REF, RFC-EDITOR, AUTH48-DONE, PENDING) are active work.
+# legacy states (edit, ref, rfc-editor, auth48-done, pending) are active work.
 LEGACY_BLOCKED_LABEL_SLUGS = frozenset(
     {
-        "TI",
-        "AUTH",
-        "AUTH48",
-        "IESG",
-        "MISSREF",
-        "IANA",
+        "ti",
+        "auth",
+        "auth48",
+        "iesg",
+        "missref",
+        "iana",
     }
 )
 
@@ -75,7 +76,9 @@ KIND_CHOICES = (KIND_BLOCKED, KIND_WORKING, KIND_LEGACY, KIND_AWAITING)
 
 # Manually-applied labels flagging a final-review doc that is waiting on a
 # referenced RFC-to-be. Only ever set while in the final_review_editor state.
-AWAITING_REF_LABEL_PREFIX = "awaiting ref:"
+# Slugified from "awaiting ref: <target>" by migration 0016, so the separator is
+# a hyphen, not the original "awaiting ref:".
+AWAITING_REF_LABEL_PREFIX = "awaiting-ref-"
 
 
 @dataclass

--- a/rpc/stats/timeline.py
+++ b/rpc/stats/timeline.py
@@ -303,6 +303,7 @@ def legacy_bands(rfc: RfcToBe) -> list[Band]:
     ).order_by("slug")
     for label in labels:
         is_blocked = label.slug in LEGACY_BLOCKED_LABEL_SLUGS
+        display = label.text or label.slug
         segments: list[Segment] = []
         for interval in rfc.time_intervals_with_label(label):
             clipped = clip(interval.start, interval.end, hi=TRANSITION_DATE)
@@ -313,14 +314,14 @@ def legacy_bands(rfc: RfcToBe) -> list[Band]:
                     start=clipped[0],
                     end=clipped[1],
                     kind=KIND_BLOCKED if is_blocked else KIND_LEGACY,
-                    label=label.slug,
+                    label=display,
                 )
             )
         if segments:
             bands.append(
                 Band(
                     kind=KIND_BLOCKED if is_blocked else KIND_LEGACY,
-                    label=label.slug,
+                    label=display,
                     segments=segments,
                 )
             )

--- a/rpc/stats/timeline.py
+++ b/rpc/stats/timeline.py
@@ -34,7 +34,6 @@ TRANSITION_DATE = datetime.datetime(2026, 5, 20, tzinfo=datetime.UTC)
 # Only these labels are reconstructed on the timeline; every other label
 # (complexity/type/exception classifications) is a persistent attribute, not a
 # time-boxed state.
-# Slugs are lowercase since migration 0016 re-slugged all labels (slugify).
 LEGACY_STATE_LABEL_SLUGS = frozenset(
     {
         "edit",
@@ -74,10 +73,9 @@ KIND_AWAITING = "awaiting_ref"
 # (and the generated TS client) expose them as an enum rather than a bare string.
 KIND_CHOICES = (KIND_BLOCKED, KIND_WORKING, KIND_LEGACY, KIND_AWAITING)
 
-# Manually-applied labels flagging a final-review doc that is waiting on a
-# referenced RFC-to-be. Only ever set while in the final_review_editor state.
-# Slugified from "awaiting ref: <target>" by migration 0016, so the separator is
-# a hyphen, not the original "awaiting ref:".
+# Slug prefix of the manually-applied labels flagging a final-review doc that is
+# waiting on a referenced RFC-to-be. Only ever set while in the
+# final_review_editor state.
 AWAITING_REF_LABEL_PREFIX = "awaiting-ref-"
 
 

--- a/rpc/tests_serializers.py
+++ b/rpc/tests_serializers.py
@@ -1,7 +1,9 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 from django.test import TestCase
 
-from .serializers import MetadataComparisonTableSerializer
+from .factories import RfcToBeFactory
+from .models import Label
+from .serializers import MetadataComparisonTableSerializer, _rfctobe_describe_delta
 
 
 class SerializerTests(TestCase):
@@ -172,4 +174,34 @@ class SerializerTests(TestCase):
         }
         self.assertEqual(
             dict(MetadataComparisonTableSerializer(INPUT_DATA).data), EXPECTED_OUTPUT
+        )
+
+
+class LabelHistoryDescriptionTests(TestCase):
+    """Label add/remove in a doc's history renders the label's current text."""
+
+    def _label_delta(self, rfc):
+        latest, previous = rfc.history.all()[:2]
+        return latest.diff_against(previous)
+
+    def test_shows_current_text_after_rename(self):
+        rfc = RfcToBeFactory()
+        label = Label.objects.create(slug="demo-hist", text="Old Name")
+        rfc.labels.add(label)
+        delta = self._label_delta(rfc)
+        label.text = "New Name"
+        label.save()
+        self.assertEqual(
+            list(_rfctobe_describe_delta(delta)), ["Label (New Name): Added"]
+        )
+
+    def test_falls_back_to_snapshot_for_deleted_label(self):
+        rfc = RfcToBeFactory()
+        label = Label.objects.create(slug="gone", text="Was Here")
+        rfc.labels.add(label)
+        delta = self._label_delta(rfc)
+        rfc.labels.remove(label)  # release the PROTECT FK before deleting
+        label.delete()
+        self.assertEqual(
+            list(_rfctobe_describe_delta(delta)), ["Label (Was Here): Added"]
         )


### PR DESCRIPTION
relates to https://github.com/ietf-tools/purple/pull/1489

some follow-up work was needed:
- update label slugs in stats
- display label text in stats
- make label text searchable in admin 
- display the label text (not slug) in doc history
- add tests