### PR TITLE
feat: use test runner and avoid output

### DIFF
--- a/purple/settings/base.py
+++ b/purple/settings/base.py
@@ -223,3 +223,6 @@ STORAGES: dict[str, dict[str, Any]] = {
     "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
     "red_bucket": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
 }
+
+# Tests
+TEST_RUNNER = "utils.test_runner.QuietLogsRunner"

--- a/rpc/lifecycle/tests.py
+++ b/rpc/lifecycle/tests.py
@@ -1,5 +1,4 @@
 # Copyright The IETF Trust 2025-2026, All Rights Reserved
-import logging
 from unittest.mock import MagicMock, patch
 
 import jsonschema.exceptions
@@ -183,7 +182,6 @@ class PublicationTests(TestCase):
         )
 
     def test_record_failed_publication_attempt(self):
-        logging.disable(logging.WARNING)  # squelch warnings
         rfc_to_be = RfcToBeFactory()
         assert isinstance(rfc_to_be, RfcToBe)
 
@@ -215,7 +213,6 @@ class PublicationTests(TestCase):
             rfc_to_be.publicationattempt.status, PublicationAttempt.Status.FAILED
         )
         self.assertEqual(rfc_to_be.publicationattempt.detail, "bad mojo")
-        logging.disable(logging.NOTSET)
 
     def test_clear_failed_publication_attempt(self):
         rfctobes = [pa.rfc_to_be for pa in PublicationAttemptFactory.create_batch(2)]

--- a/utils/test_runner.py
+++ b/utils/test_runner.py
@@ -1,0 +1,35 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+"""Test runner that keeps log output off the console"""
+
+import logging
+
+from django.test.runner import DiscoverRunner
+
+
+class QuietLogsRunner(DiscoverRunner):
+    """Silence configured log handlers while tests run; --show-logs restores them.
+
+    Handlers are raised rather than loggers so assertLogs, which attaches its own
+    handler, keeps working regardless of the active LOGGING config.
+    """
+
+    def __init__(self, *, show_logs=False, **kwargs):
+        super().__init__(**kwargs)
+        self.show_logs = show_logs
+
+    @classmethod
+    def add_arguments(cls, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--show-logs",
+            action="store_true",
+            help="Let log output reach the console during tests.",
+        )
+
+    def setup_test_environment(self, **kwargs):
+        super().setup_test_environment(**kwargs)
+        if self.show_logs:
+            return
+        for logger in (logging.root, *logging.root.manager.loggerDict.values()):
+            for handler in getattr(logger, "handlers", ()):
+                handler.setLevel(logging.CRITICAL + 1)

--- a/utils/test_runner.py
+++ b/utils/test_runner.py
@@ -1,19 +1,35 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
-"""Test runner that keeps log output off the console"""
+"""Test runner that shows log output only for failing tests"""
 
 import logging
+import sys
 
 from django.test.runner import DiscoverRunner
 
 
-class QuietLogsRunner(DiscoverRunner):
-    """Silence configured log handlers while tests run; --show-logs restores them.
+class _SysStream:
+    """Resolve sys.stdout/sys.stderr on every write so buffer mode can swap them."""
 
-    Handlers are raised rather than loggers so assertLogs, which attaches its own
-    handler, keeps working regardless of the active LOGGING config.
+    def __init__(self, name):
+        self._name = name
+
+    def write(self, s):
+        return getattr(sys, self._name).write(s)
+
+    def flush(self):
+        getattr(sys, self._name).flush()
+
+
+class QuietLogsRunner(DiscoverRunner):
+    """Buffer per-test output, printing it only under failures; --show-logs shows all.
+
+    StreamHandler binds its stream at logging setup, before unittest's buffering
+    replaces sys.stderr, so console handlers are re-pointed at a lazy proxy.
     """
 
     def __init__(self, *, show_logs=False, **kwargs):
+        if not show_logs:
+            kwargs["buffer"] = True
         super().__init__(**kwargs)
         self.show_logs = show_logs
 
@@ -23,7 +39,7 @@ class QuietLogsRunner(DiscoverRunner):
         parser.add_argument(
             "--show-logs",
             action="store_true",
-            help="Let log output reach the console during tests.",
+            help="Print log output from every test, not just failing ones.",
         )
 
     def setup_test_environment(self, **kwargs):
@@ -32,4 +48,8 @@ class QuietLogsRunner(DiscoverRunner):
             return
         for logger in (logging.root, *logging.root.manager.loggerDict.values()):
             for handler in getattr(logger, "handlers", ()):
-                handler.setLevel(logging.CRITICAL + 1)
+                stream = getattr(handler, "stream", None)
+                if stream is sys.stderr:
+                    handler.setStream(_SysStream("stderr"))
+                elif stream is sys.stdout:
+                    handler.setStream(_SysStream("stdout"))


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1520

new output 
```
dev ➜ /workspace $ ./manage.py test
Found 157 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.............................................................................................................................................................
----------------------------------------------------------------------
Ran 157 tests in 9.043s

OK
Destroying test database for alias 'default'...
```